### PR TITLE
22 read only vocabularies

### DIFF
--- a/invenio_vocabularies/cli.py
+++ b/invenio_vocabularies/cli.py
@@ -13,13 +13,10 @@ import csv
 from os.path import dirname, join
 
 import click
-import pycountry
-from babel import Locale, UnknownLocaleError
 from flask.cli import with_appcontext
 from flask_principal import Identity
 from invenio_access import any_user
 from invenio_db import db
-from invenio_i18n.ext import current_i18n
 
 from invenio_vocabularies.contrib.subjects.subjects import subject_record_type
 from invenio_vocabularies.records.models import VocabularyType

--- a/invenio_vocabularies/resources/resource.py
+++ b/invenio_vocabularies/resources/resource.py
@@ -128,12 +128,12 @@ class VocabulariesResource(RecordResource):
     @item_route
     def delete(self):
         """Delete an item."""
-        return super().read()
+        return super().delete()
 
     @item_route
     def update(self):
         """Update an item."""
-        return super().read()
+        return super().update()
 
     @list_route
     def search(self):

--- a/invenio_vocabularies/services/permissions.py
+++ b/invenio_vocabularies/services/permissions.py
@@ -9,19 +9,19 @@
 """Vocabulary permissions."""
 
 from invenio_records_permissions import RecordPermissionPolicy
-from invenio_records_permissions.generators import AnyUser
+from invenio_records_permissions.generators import AnyUser, SystemProcess
 
 
 class PermissionPolicy(RecordPermissionPolicy):
     """Permission policy."""
 
     # TODO: restrict to not allow create/update/delete
-    can_search = [AnyUser()]
-    can_create = [AnyUser()]
-    can_read = [AnyUser()]
-    can_update = [AnyUser()]
-    can_delete = [AnyUser()]
-    can_manage = [AnyUser()]
+    can_search = [SystemProcess(), AnyUser()]
+    can_read = [SystemProcess(), AnyUser()]
+    can_create = [SystemProcess()]
+    can_update = [SystemProcess()]
+    can_delete = [SystemProcess()]
+    can_manage = [SystemProcess()]
 
     # Type permissions
-    can_manage = [AnyUser()]
+    can_manage = [SystemProcess()]

--- a/invenio_vocabularies/version.py
+++ b/invenio_vocabularies/version.py
@@ -12,4 +12,4 @@ This file is imported by ``invenio_vocabularies.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/setup.py
+++ b/setup.py
@@ -59,9 +59,8 @@ setup_requires = [
 ]
 
 install_requires = [
-    "invenio-records-resources>=0.11.0",
+    "invenio-records-resources>=0.12.1",
     "invenio-i18n>=1.3.0",
-    "pycountry>=18.12.8",
 ]
 
 packages = find_packages()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ fixtures are available.
 
 import pytest
 from flask_principal import Identity, Need, UserNeed
-from invenio_access import any_user
+from invenio_access.permissions import any_user, system_process
 from invenio_app.factory import create_api as _create_api
 
 from invenio_vocabularies.records.api import Vocabulary
@@ -76,6 +76,7 @@ def identity():
     i = Identity(1)
     i.provides.add(UserNeed(1))
     i.provides.add(any_user)
+    i.provides.add(system_process)
     return i
 
 

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -10,7 +10,7 @@
 
 import pytest
 from flask_principal import Identity
-from invenio_access import any_user
+from invenio_access.permissions import any_user, system_process
 from invenio_indexer.api import RecordIndexer
 
 from invenio_vocabularies.records.api import Vocabulary
@@ -21,6 +21,7 @@ def identity():
     """Simple identity to interact with the service."""
     identity = Identity(1)
     identity.provides.add(any_user)
+    identity.provides.add(system_process)
     return identity
 
 

--- a/tests/services/test_permissions.py
+++ b/tests/services/test_permissions.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2020-2021 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Test the vocabulary service."""
+
+import pytest
+from flask_principal import Identity, PermissionDenied
+from invenio_access.permissions import any_user, system_identity
+
+from invenio_vocabularies.records.api import Vocabulary
+
+
+#
+# Fixtures
+#
+@pytest.fixture()
+def anyuser_idty():
+    """Simple identity to interact with the service."""
+    identity = Identity(1)
+    identity.provides.add(any_user)
+    return identity
+
+
+#
+# Tests
+#
+def test_permissions_readonly(anyuser_idty, lang_type, lang_data, service):
+    """Read-only permission test.
+
+    These tests will eventually need to be rewritten once a more advanced
+    permission policy is put in place. Currently the permission policy only
+    allows a system process to create/update/delete vocabularies.
+    """
+    # Create - only system allowed
+    pytest.raises(PermissionDenied, service.create, anyuser_idty, lang_data)
+    item = service.create(system_identity, lang_data)
+    id_ = item.id
+
+    # Read - both allowed
+    item = service.read(('languages', id_), anyuser_idty, lang_data)
+    item = service.read(('languages', id_), system_identity, lang_data)
+
+    # Refresh index to make changes live.
+    Vocabulary.index.refresh()
+
+    # Search - both allowed
+    res = service.search(
+        anyuser_idty, type='languages', q=f"id:{id_}", size=25, page=1)
+    assert res.total == 1
+    res = service.search(
+        system_identity, type='languages', q=f"id:{id_}", size=25, page=1)
+    assert res.total == 1
+
+    # Update - only system allowed
+    data = item.data
+    data['title']['en'] = 'New title'
+    pytest.raises(
+        PermissionDenied, service.update, ('languages', id_), anyuser_idty,
+        data)
+    service.update(('languages', id_), system_identity, data)
+
+    # Delete - only system allowed
+    pytest.raises(
+        PermissionDenied, service.delete, ('languages', id_), anyuser_idty)
+    service.delete(('languages', id_), system_identity)


### PR DESCRIPTION
closes #22 

requires the `SystemProcess` generator defined in https://github.com/inveniosoftware/invenio-records-permissions/pull/62