### PR TITLE
bump invenio-db (formerly: add service.rebuild_index)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ tests_require = [
 
 # Should follow inveniosoftware/invenio versions
 invenio_search_version = ">=1.4.1,<2.0.0"
-invenio_db_version = ">=1.0.5,<2.0.0"
+invenio_db_version = ">=1.0.8,<2.0.0"
 
 extras_require = {
     "docs": [


### PR DESCRIPTION
closes inveniosoftware/invenio-rdm-records#441

add a new service method for reindexing vocabularies

EDIT: this one basically reverted to a bump of invenio-db, because `rebuild_index` has been moved to `invenio-records-resources` (inveniosoftware/invenio-records-resources/pull/211)