### PR TITLE
services: add support for filtered read_all

### DIFF
--- a/invenio_vocabularies/services/facets.py
+++ b/invenio_vocabularies/services/facets.py
@@ -44,7 +44,8 @@ class VocabularyLabels:
             vocabs = current_service.read_many(
                 identity, ids, fields=self.fields)
         else:
-            vocabs = current_service.read_all(identity, fields=self.fields)
+            vocabs = current_service.read_all(
+                identity, type=self.vocabulary, fields=self.fields)
 
         labels = {}
         vocab_list = list(vocabs.hits)  # the service returns a generator


### PR DESCRIPTION
requires https://github.com/inveniosoftware/invenio-records-resources/pull/250
closes #38 

- Note there is a parameter order change in the service methods to make the vocabulary type mandatory
- No tests are added since the method was already tested by the `test_facets.py` (not a valid excuse, but is good for now)