### PR TITLE
facets: add nested vocabulary facet and label

### DIFF
--- a/invenio_vocabularies/services/facets/__init__.py
+++ b/invenio_vocabularies/services/facets/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Vocabulary facets."""
+
+from .facets import NestedVocabularyTermsFacet
+from .labels import VocabularyLabels
+
+__all__ = (
+    "NestedVocabularyTermsFacet",
+    "VocabularyLabels",
+)

--- a/invenio_vocabularies/services/facets/facets.py
+++ b/invenio_vocabularies/services/facets/facets.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Vocabulary facets."""
+
+from bisect import bisect, bisect_left
+
+from elasticsearch_dsl import AttrDict
+from invenio_records_resources.services.records.facets import TermsFacet
+
+
+class LabellingBucket(AttrDict):
+    """Bucket class to allow label extration."""
+
+    def __init__(self, key, doc_count):
+        """Constructor."""
+        super().__init__({"key": key, "doc_count": doc_count})
+
+
+class NestedVocabularyTermsFacet(TermsFacet):
+    """A term facet for vocabularies with nested/hierarchical labelling."""
+
+    def __init__(self, splitchar="-", **kwargs):
+        """Initialize the nested vocabulary terms facet."""
+        self._splitchar = splitchar
+        super().__init__(**kwargs)
+
+    def _build_nested_buckets(self, buckets):
+        """Build nested buckets from a vocabulary facet.
+
+        This function will return a flattened list of buckets. The input
+        will be a list of ES buckets with, potentially, a nested key.
+        That means, dash separated values (e.g. image-drawing). The output
+        be [image, image-drawing], so the parent (i.e. image) of the nested
+        aggregation is also queried to ES (to get the UI label).
+        In addition, it will calculate the aggregated value of the parent
+        doc_count.
+
+        For example, doc_count in parenthesis:
+        bucket.data = [
+            image-png(2), image-jpg(5), publication(3), publication-book(1)
+        ]
+        buckets_out = [
+            image(7), image-jpg(5), image-png(2),
+            publication(4), publication-book(1)
+        ]
+        """
+        seen = set()
+        buckets_idx = []  # avoid implementing __lt__ for bisect on buckets
+        buckets_out = []  # sorted, non duplicates buckets
+        for bucket in buckets:
+            key = self.get_value(bucket)
+            metric = self.get_metric(bucket)
+            nested = key.split(self._splitchar)
+
+            root = ""
+            for facet in nested[:-1]:
+                root = facet if not root else root + "-" + facet
+                if root not in seen:
+                    seen.add(root)
+                    idx = bisect(buckets_idx, root)
+                    buckets_out.insert(idx, LabellingBucket(root, metric))
+                    buckets_idx.insert(idx, root)  # add root to idx
+                else:  # update aggregated count
+                    idx = bisect_left(buckets_idx, root)
+                    buckets_out[idx].doc_count += metric
+
+            if key not in seen:  # Add the last bucket
+                seen.add(key)
+                idx = bisect(buckets_idx, key)
+                buckets_out.insert(idx, bucket)
+                buckets_idx.insert(idx, key)  # add full key to idx
+
+        return buckets_out
+
+    def _build_bucket_out(self, bucket, label_map, key_prefix, filter_values):
+        """Build a single bucket output."""
+        key = full_key = bucket.key
+        if key_prefix:
+            full_key = key_prefix + self._splitchar + full_key
+
+        bucket_out = {
+            "key": key,
+            "doc_count": self.get_metric(bucket),
+            "label": label_map[key],
+            "is_selected": self.is_filtered(full_key, filter_values)
+        }
+
+        return bucket_out
+
+    def _build_bucket_list(
+        self, buckets, label_map, key_prefix, filter_values,
+        idx=0, inner=False
+    ):
+        """Recursively builds bucket dictionary."""
+        # check the test_facets.py::test_nested_vocabulary_facet_labelling
+        # to see an example ouput of the function call
+        buckets_out = []
+        bucket = buckets[idx]
+        bucket_out = self._build_bucket_out(
+            bucket, label_map, key_prefix, filter_values)
+
+        buckets_inner = []
+        while idx+1 < len(buckets):
+            if bucket.key in buckets[idx+1].key:  # is a child
+                idx, bucket_inner = self._build_bucket_list(
+                    buckets, label_map, key_prefix, filter_values, idx+1, True)
+                buckets_inner.extend(bucket_inner)
+            elif inner:  # finish the children cycle
+                break
+            else:  # add current root and get next
+                if buckets_inner:
+                    bucket_out["inner"] = {'buckets': buckets_inner}
+                buckets_out.append(bucket_out)
+                idx += 1
+                bucket = buckets[idx]
+                bucket_out = self._build_bucket_out(
+                    bucket, label_map, key_prefix, filter_values)
+                buckets_inner = []
+
+        if buckets_inner:
+            bucket_out["inner"] = {'buckets': buckets_inner}
+
+        buckets_out.append(bucket_out)
+
+        return idx, buckets_out
+
+    def get_labelled_values(self, data, filter_values, bucket_label=True,
+                            key_prefix=None):
+        """Get a labelled version of a bucket."""
+        out = []
+        # We get the labels first, so that we can efficiently query a resource
+        # for all keys in one go, vs querying one by one if needed.
+        label_buckets = self._build_nested_buckets(data.buckets)
+        label_map = self.get_label_mapping(label_buckets)
+
+        _, out = self._build_bucket_list(
+            label_buckets, label_map, key_prefix, filter_values
+        )
+        ret_val = {'buckets': out}
+
+        if bucket_label:
+            ret_val['label'] = str(self._label)
+        return ret_val

--- a/invenio_vocabularies/services/facets/labels.py
+++ b/invenio_vocabularies/services/facets/labels.py
@@ -6,14 +6,14 @@
 # modify it under the terms of the MIT License; see LICENSE file for more
 # details.
 
-"""Vocabulary facets."""
+"""Vocabulary facet labels."""
 
 from flask_principal import AnonymousIdentity
 from invenio_i18n.ext import current_i18n
 from marshmallow_utils.fields.babel import gettext_from_dict
 from speaklater import make_lazy_string
 
-from ..proxies import current_service
+from ...proxies import current_service
 
 
 def lazy_get_label(vocab_item):

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -9,8 +9,6 @@
 """Vocabularies test config."""
 
 import pytest
-from flask_principal import Identity
-from invenio_access.permissions import any_user, system_process
 from invenio_indexer.api import RecordIndexer
 
 from invenio_vocabularies.records.api import Vocabulary

--- a/tests/services/test_facets.py
+++ b/tests/services/test_facets.py
@@ -10,68 +10,141 @@
 """Test the vocabulary service facets."""
 
 import pytest
+from flask_babelex import lazy_gettext as _
+from invenio_access.permissions import system_identity
 
+from invenio_vocabularies.proxies import current_service
 from invenio_vocabularies.records.api import Vocabulary
-from invenio_vocabularies.services.facets import VocabularyLabels
+from invenio_vocabularies.services.facets import NestedVocabularyTermsFacet, \
+    VocabularyLabels
+from invenio_vocabularies.services.facets.facets import LabellingBucket
 
 
-@pytest.fixture(scope='module')
-def example_data():
-    """Example data."""
-    return [
-        {
-            'id': 'eng',
-            'title': {'en': 'English', 'da': 'Engelsk'},
-            'type': 'languages',
-        },
-        {
-            'id': 'spa',
-            'title': {'en': 'Spanish', 'da': 'Spansk'},
-            'type': 'languages',
-        },
-        {
-            'id': 'fra',
-            'title': {'en': 'French', 'da': 'Fransk'},
-            'type': 'languages',
-        },
+class DummyData:
+    """Dummy data with buckets."""
+    buckets = [
+        LabellingBucket("rootone", 2),
+        LabellingBucket("rootone-subone", 1),
+        LabellingBucket("rootone-subone-subone", 4),
+        LabellingBucket("rootone-subtwo", 3),
+        LabellingBucket("roottwo", 5)
     ]
 
 
-@pytest.fixture(scope='module')
-def example_records(database, identity, service, example_data):
-    """Create some example records."""
-    service.create_type(identity, 'languages', 'lng')
-    records = []
-    for data in example_data:
-        records.append(service.create(identity, data))
+def test_nested_vocabulary_facet_labelling(app):
+    # create vocabulary type
+    current_service.create_type(system_identity, "nested_vocab", "nes")
+
+    # add vocabulary items
+    current_service.create(system_identity, {
+        "id": "rootone",
+        "props": {
+            "type": "rootone",
+            "type_name": "rootone",
+        },
+        "title": {
+            "en": "Root One"
+        },
+        "type": "nested_vocab"
+    })
+
+    current_service.create(system_identity, {
+        "id": "rootone-subone",
+        "props": {
+            "type": "rootone-subone",
+            "type_name": "rootone-subone",
+        },
+        "title": {
+            "en": "Root One Sub One"
+        },
+        "type": "nested_vocab"
+    })
+
+    current_service.create(system_identity, {
+        "id": "rootone-subtwo",
+        "props": {
+            "type": "rootone-subtwo",
+            "type_name": "rootone-subtwo",
+        },
+        "title": {
+            "en": "Root One Sub Two"
+        },
+        "type": "nested_vocab"
+    })
+
+    current_service.create(system_identity, {
+        "id": "rootone-subone-subone",
+        "props": {
+            "type": "rootone-subone-subone",
+            "type_name": "rootone-subone-subone",
+        },
+        "title": {
+            "en": "Root One Sub Sub One"
+        },
+        "type": "nested_vocab"
+    })
+
+    current_service.create(system_identity, {
+        "id": "roottwo",
+        "props": {
+            "type": "roottwo",
+            "type_name": "roottwo",
+        },
+        "title": {
+            "en": "Root Two"
+        },
+        "type": "nested_vocab"
+    })
 
     Vocabulary.index.refresh()
-    return records
 
+    # expected data
+    nested_item_labels = {'buckets': [
+        {
+            'key': 'rootone',
+            'doc_count': 10,  # 2 + 1 + 4 + 3
+            'label': _('Root One'),
+            'is_selected': False,
+            'inner': {'buckets': [
+                {
+                    'key': 'rootone-subone',
+                    'doc_count': 5,  # 1 + 4
+                    'label': _('Root One Sub One'),
+                    'is_selected': False,
+                    'inner': {'buckets': [
+                        {
+                            'key': 'rootone-subone-subone',
+                            'doc_count': 4,
+                            'label': _('Root One Sub Sub One'),
+                            'is_selected': False
+                        }
+                    ]}
+                }, {
+                    'key': 'rootone-subtwo',
+                    'doc_count': 3,
+                    'label': _('Root One Sub Two'),
+                    'is_selected': False
+                }
+            ]}
+        }, {
+            'key': 'roottwo',
+            'doc_count': 5,
+            'label': _('Root Two'),
+            'is_selected': False
+        }],
+        'label': 'Nested Aggs'
+    }
 
-def _assert_vocabs(labels_instance):
-    labels = labels_instance(["eng", "spa"])
+    nested_buckets = DummyData()
 
-    assert labels["eng"] == "English"
-    assert labels["spa"] == "Spanish"
+    # the test
+    resource_type_facet = NestedVocabularyTermsFacet(
+        field='dummy.not.used',
+        label=_("Nested Aggs"),
+        value_labels=VocabularyLabels('nested_vocab')
+    )
 
+    aggs_labels = resource_type_facet.get_labelled_values(
+        data=nested_buckets, filter_values=())
 
-def test_vocabulary_label_cache(example_records):
-    # Uses example record to have two languages created on the vocabulary
-    labels_instance = VocabularyLabels(vocabulary="languages", cache=True)
-    _assert_vocabs(labels_instance)
-
-
-def test_vocabulary_label_no_cache(example_records):
-    # Uses example record to have two languages created on the vocabulary
-    labels_instance = VocabularyLabels(vocabulary="languages", cache=False)
-    _assert_vocabs(labels_instance)
-
-
-def test_vocabulary_label_not_found(example_records):
-    # Uses example record to have two languages created on the vocabulary
-    labels_instance = VocabularyLabels(vocabulary="languages", cache=True)
-    labels = labels_instance(["eng", "glg"])
-
-    assert labels["eng"] == "English"
-    assert not labels.get("glg")  # search wont fail
+    assert nested_item_labels == aggs_labels

--- a/tests/services/test_labels.py
+++ b/tests/services/test_labels.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2021 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Test the vocabulary service facet labels."""
+
+import pytest
+
+from invenio_vocabularies.records.api import Vocabulary
+from invenio_vocabularies.services.facets import VocabularyLabels
+
+
+@pytest.fixture(scope='module')
+def example_data():
+    """Example data."""
+    return [
+        {
+            'id': 'eng',
+            'title': {'en': 'English', 'da': 'Engelsk'},
+            'type': 'languages',
+        },
+        {
+            'id': 'spa',
+            'title': {'en': 'Spanish', 'da': 'Spansk'},
+            'type': 'languages',
+        },
+        {
+            'id': 'fra',
+            'title': {'en': 'French', 'da': 'Fransk'},
+            'type': 'languages',
+        },
+    ]
+
+
+@pytest.fixture(scope='module')
+def example_records(database, identity, service, example_data):
+    """Create some example records."""
+    service.create_type(identity, 'languages', 'lng')
+    records = []
+    for data in example_data:
+        records.append(service.create(identity, data))
+
+    Vocabulary.index.refresh()
+    return records
+
+
+def _assert_vocabs(labels_instance):
+    labels = labels_instance(["eng", "spa"])
+
+    assert labels["eng"] == "English"
+    assert labels["spa"] == "Spanish"
+
+
+def test_vocabulary_label_cache(example_records):
+    # Uses example record to have two languages created on the vocabulary
+    labels_instance = VocabularyLabels(vocabulary="languages", cache=True)
+    _assert_vocabs(labels_instance)
+
+
+def test_vocabulary_label_no_cache(example_records):
+    # Uses example record to have two languages created on the vocabulary
+    labels_instance = VocabularyLabels(vocabulary="languages", cache=False)
+    _assert_vocabs(labels_instance)
+
+
+def test_vocabulary_label_not_found(example_records):
+    # Uses example record to have two languages created on the vocabulary
+    labels_instance = VocabularyLabels(vocabulary="languages", cache=True)
+    labels = labels_instance(["eng", "glg"])
+
+    assert labels["eng"] == "English"
+    assert not labels.get("glg")  # search wont fail


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-rdm-records/issues/628

Example output for resource_types:

```
{
  "aggregations": {
    "resource_type": {
      "buckets": [
        {
          "key": "image",
          "doc_count": 10,
          "label": "Image",
          "is_selected": false,
          "inner": {
            "buckets": [
            {
              "key": "image-diagram",
              "doc_count": 4,
              "label": "Diagram",
              "is_selected": false
            },
            {
              "key": "image-other",
              "doc_count": 6,
              "label": "Other",
              "is_selected": false
            }
          ]
        },
        ...
```

![Screenshot 2021-06-07 at 08 55 58](https://user-images.githubusercontent.com/6756943/120972773-659c3c80-c76e-11eb-922c-120abcd3de7d.png)

