### PR TITLE
i18n: fix missing message catalog

### DIFF
--- a/invenio_vocabularies/translations/en/LC_MESSAGES/messages.po
+++ b/invenio_vocabularies/translations/en/LC_MESSAGES/messages.po
@@ -1,0 +1,53 @@
+# English translations for invenio-vocabularies.
+# Copyright (C) 2021 CERN
+# Copyright (C) 2021 Graz University of Technology.
+# This file is distributed under the same license as the
+# invenio-vocabularies project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: invenio-vocabularies 0.7.7\n"
+"Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
+"POT-Creation-Date: 2021-07-13 11:06+0200\n"
+"PO-Revision-Date: 2021-07-14 16:49+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: en\n"
+"Language-Team: en <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+
+#: invenio_vocabularies/contrib/affiliations/config.py:39
+#: invenio_vocabularies/contrib/subjects/config.py:38
+#: invenio_vocabularies/services/service.py:55
+msgid "Best match"
+msgstr ""
+
+#: invenio_vocabularies/contrib/affiliations/config.py:43
+#: invenio_vocabularies/contrib/subjects/config.py:42
+msgid "Name"
+msgstr ""
+
+#: invenio_vocabularies/contrib/affiliations/config.py:47
+#: invenio_vocabularies/contrib/subjects/config.py:46
+#: invenio_vocabularies/services/service.py:63
+msgid "Newest"
+msgstr ""
+
+#: invenio_vocabularies/contrib/affiliations/config.py:51
+#: invenio_vocabularies/contrib/subjects/config.py:50
+#: invenio_vocabularies/services/service.py:67
+msgid "Oldest"
+msgstr ""
+
+#: invenio_vocabularies/services/components.py:31
+msgid "The vocabulary type does not exists."
+msgstr ""
+
+#: invenio_vocabularies/services/service.py:59
+msgid "Title"
+msgstr ""
+


### PR DESCRIPTION
* At least one message catalog is required for compile_catalog to work
  otherwise the PyPI publishing will fail.