### PR TITLE
names: add contrib vocabulary

### DIFF
--- a/invenio_vocabularies/alembic/17c703ce1eb7_create_names_table.py
+++ b/invenio_vocabularies/alembic/17c703ce1eb7_create_names_table.py
@@ -1,0 +1,58 @@
+#
+# This file is part of Invenio.
+# Copyright (C) 2021 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Create names table."""
+
+import sqlalchemy as sa
+import sqlalchemy_utils
+from alembic import op
+from sqlalchemy.dialects import mysql, postgresql
+
+# revision identifiers, used by Alembic.
+revision = '17c703ce1eb7'
+down_revision = '4a9a4fd235f8'
+branch_labels = ()
+depends_on = None
+
+
+def upgrade():
+    """Upgrade database."""
+    op.create_table(
+        'name_metadata',
+        sa.Column(
+            'created',
+            sa.DateTime().with_variant(mysql.DATETIME(fsp=6), 'mysql'),
+            nullable=False
+        ),
+        sa.Column(
+            'updated',
+            sa.DateTime().with_variant(mysql.DATETIME(fsp=6), 'mysql'),
+            nullable=False
+        ),
+        sa.Column(
+            'id',
+            sqlalchemy_utils.types.uuid.UUIDType(),
+            nullable=False
+        ),
+        sa.Column(
+            'json',
+            sa.JSON()
+            .with_variant(sqlalchemy_utils.types.json.JSONType(), 'mysql')
+            .with_variant(
+                postgresql.JSONB(none_as_null=True, astext_type=sa.Text()),
+                'postgresql')
+            .with_variant(sqlalchemy_utils.types.json.JSONType(), 'sqlite'),
+            nullable=True
+        ),
+        sa.Column('version_id', sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint('id', name=op.f('pk_name_metadata'))
+    )
+
+
+def downgrade():
+    """Downgrade database."""
+    op.drop_table('name_metadata')

--- a/invenio_vocabularies/config.py
+++ b/invenio_vocabularies/config.py
@@ -10,6 +10,7 @@
 """Vocabularies configuration."""
 
 import idutils
+from flask_babelex import lazy_gettext as _
 
 from .resources.resource import VocabulariesResourceConfig
 from .services.service import VocabulariesServiceConfig
@@ -22,20 +23,34 @@ VOCABULARIES_SERVICE_CONFIG = VocabulariesServiceConfig
 
 VOCABULARIES_AFFILIATION_SCHEMES = {
     "grid": {
-        "label": "GRID",
+        "label": _("GRID"),
         "validator": lambda x: True
     },
     "gnd": {
-        "label": "GND",
+        "label": _("GND"),
         "validator": idutils.is_gnd
     },
     "isni": {
-        "label": "ISNI",
+        "label": _("ISNI"),
         "validator": idutils.is_isni
     },
     "ror": {
-        "label": "ROR",
+        "label": _("ROR"),
         "validator": idutils.is_ror
     },
 }
 """Affiliations allowed identifier schemes."""
+
+VOCABULARIES_NAMES_SCHEMES = {
+    "orcid": {
+        "label": _("ORCID"),
+        "validator": idutils.is_orcid,
+        "datacite": "ORCID"
+    },
+    "gnd": {
+        "label": _("GND"),
+        "validator": idutils.is_gnd,
+        "datacite": "GND"
+    }
+}
+"""Names allowed identifier schemes."""

--- a/invenio_vocabularies/contrib/names/__init__.py
+++ b/invenio_vocabularies/contrib/names/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Names module."""

--- a/invenio_vocabularies/contrib/names/__init__.py
+++ b/invenio_vocabularies/contrib/names/__init__.py
@@ -8,9 +8,12 @@
 
 """Names module."""
 
+from .resources import NamesResource, NamesResourceConfig
 from .services import NamesService, NamesServiceConfig
 
-__all__ = [
+__all__ = (
+    "NamesResource",
+    "NamesResourceConfig"
     "NamesService",
     "NamesServiceConfig",
-]
+)

--- a/invenio_vocabularies/contrib/names/api.py
+++ b/invenio_vocabularies/contrib/names/api.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Vocabulary names."""
+
+from .names import record_type
+
+Name = record_type.record_cls

--- a/invenio_vocabularies/contrib/names/config.py
+++ b/invenio_vocabularies/contrib/names/config.py
@@ -1,3 +1,4 @@
+
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2021 CERN.
@@ -6,7 +7,7 @@
 # modify it under the terms of the MIT License; see LICENSE file for more
 # details.
 
-"""Vocabulary affiliations configuration."""
+"""Vocabulary names configuration."""
 
 from flask import current_app
 from flask_babelex import lazy_gettext as _
@@ -18,21 +19,20 @@ from werkzeug.local import LocalProxy
 
 from ...services.components import PIDComponent
 
-affiliation_schemes = LocalProxy(
-     lambda: current_app.config["VOCABULARIES_AFFILIATION_SCHEMES"]
+names_schemes = LocalProxy(
+     lambda: current_app.config["VOCABULARIES_NAMES_SCHEMES"]
 )
 
 
-class AffiliationsSearchOptions(SearchOptions):
+class NamesSearchOptions(SearchOptions):
     """Search options."""
 
     suggest_parser_cls = SuggestQueryParser.factory(
         fields=[
             'name^100',
-            'acronym^20',
-            'title.*^5',
-            'title.*._2gram',
-            'title.*._3gram',
+            'family_name^100',
+            'given_name^100',
+            'identifiers.identifier^20',
         ],
     )
 

--- a/invenio_vocabularies/contrib/names/config.py
+++ b/invenio_vocabularies/contrib/names/config.py
@@ -33,6 +33,7 @@ class NamesSearchOptions(SearchOptions):
             'family_name^100',
             'given_name^100',
             'identifiers.identifier^20',
+            'affiliations.name^10',
         ],
     )
 

--- a/invenio_vocabularies/contrib/names/jsonschemas/__init__.py
+++ b/invenio_vocabularies/contrib/names/jsonschemas/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""JSONSchema directory."""

--- a/invenio_vocabularies/contrib/names/jsonschemas/names/name-v1.0.0.json
+++ b/invenio_vocabularies/contrib/names/jsonschemas/names/name-v1.0.0.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "local://names/name-v1.0.0.json",
+  "description": "Names vocabulary.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "$ref": "local://definitions-v1.0.0.json#/$schema"
+    },
+    "id": {
+      "description": "URI or classification code as identifier - globally unique among all names schemes.",
+      "$ref": "local://definitions-v1.0.0.json#/identifier"
+    },
+    "pid": {
+      "$ref": "local://definitions-v1.0.0.json#/internal-pid"
+    },
+    "scheme": {
+      "description": "Identifier of the name scheme.",
+      "$ref": "local://definitions-v1.0.0.json#/identifier"
+    },
+    "name": {"type": "string"},
+    "given_name": {"type": "string"},
+    "family_name": {"type": "string"},
+    "identifiers": {
+      "description": "Identifiers for the person.",
+      "type": "array",
+      "items": {"$ref": "local://definitions-v1.0.0.json#/identifiers_with_scheme"},
+      "uniqueItems": true
+    },
+    "affiliations": {
+      "description": "Affiliations of the person.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "$ref": "local://definitions-v1.0.0.json#/identifier"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "uniqueItems": true
+    }
+  }
+}

--- a/invenio_vocabularies/contrib/names/mappings/v6/__init__.py
+++ b/invenio_vocabularies/contrib/names/mappings/v6/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Names Elasticsearch v6 mappings."""

--- a/invenio_vocabularies/contrib/names/mappings/v6/names/name-v1.0.0.json
+++ b/invenio_vocabularies/contrib/names/mappings/v6/names/name-v1.0.0.json
@@ -1,0 +1,82 @@
+{
+  "mappings": {
+    "_doc": {
+      "dynamic": "strict",
+      "properties": {
+        "$schema": {
+          "type": "keyword",
+          "index": "false"
+        },
+        "created": {
+          "type": "date"
+        },
+        "updated": {
+          "type": "date"
+        },
+        "uuid": {
+          "type": "keyword"
+        },
+        "version_id": {
+          "type": "integer"
+        },
+        "id": {
+          "type": "keyword"
+        },
+        "name_sort": {
+          "type": "keyword"
+        },
+        "name": {
+          "type": "text",
+          "copy_to": "name_sort"
+        },
+        "given_name": {
+          "type": "text"
+        },
+        "family_name": {
+          "type": "text"
+        },
+        "identifiers": {
+          "properties": {
+            "identifier" : {
+              "type" : "keyword"
+            },
+            "scheme" : {
+              "type" : "keyword"
+            }
+          }
+        },
+        "affiliations": {
+          "type": "object",
+          "properties": {
+            "@v": {
+              "type": "keyword"
+            },
+            "id": {
+              "type": "keyword"
+            },
+            "name": {
+              "type": "keyword"
+            }
+          }
+        },
+        "pid": {
+          "type": "object",
+          "properties": {
+            "pk": {
+              "type": "integer"
+            },
+            "pid_type": {
+              "type": "keyword"
+            },
+            "obj_type": {
+              "type": "keyword"
+            },
+            "status": {
+              "type": "keyword"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/invenio_vocabularies/contrib/names/mappings/v7/__init__.py
+++ b/invenio_vocabularies/contrib/names/mappings/v7/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Names Elasticsearch v7 mappings."""

--- a/invenio_vocabularies/contrib/names/mappings/v7/names/name-v1.0.0.json
+++ b/invenio_vocabularies/contrib/names/mappings/v7/names/name-v1.0.0.json
@@ -1,0 +1,90 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "$schema": {
+        "type": "keyword",
+        "index": "false"
+      },
+      "created": {
+        "type": "date"
+      },
+      "updated": {
+        "type": "date"
+      },
+      "uuid": {
+        "type": "keyword"
+      },
+      "version_id": {
+        "type": "integer"
+      },
+      "id": {
+        "type": "keyword"
+      },
+      "name_sort": {
+        "type": "keyword"
+      },
+      "name": {
+        "type": "text",
+        "copy_to": "name_sort",
+        "fields": {
+          "suggest": {
+            "type": "search_as_you_type"
+          }
+        }
+      },
+      "given_name": {
+        "type": "text"
+      },
+      "family_name": {
+        "type": "text"
+      },
+      "identifiers": {
+        "properties": {
+          "identifier" : {
+            "type" : "keyword",
+            "fields": {
+              "suggest": {
+                "type": "search_as_you_type"
+              }
+            }
+          },
+          "scheme" : {
+            "type" : "keyword"
+          }
+        }
+      },
+      "affiliations": {
+        "type": "object",
+        "properties": {
+          "@v": {
+            "type": "keyword"
+          },
+          "id": {
+            "type": "keyword"
+          },
+          "name": {
+            "type": "keyword"
+          }
+        }
+      },
+      "pid": {
+        "type": "object",
+        "properties": {
+          "pk": {
+            "type": "integer"
+          },
+          "pid_type": {
+            "type": "keyword"
+          },
+          "obj_type": {
+            "type": "keyword"
+          },
+          "status": {
+            "type": "keyword"
+          }
+        }
+      }
+    }
+  }
+}

--- a/invenio_vocabularies/contrib/names/models.py
+++ b/invenio_vocabularies/contrib/names/models.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Vocabulary names."""
+
+from .names import record_type
+
+NamesMetadata = record_type.model_cls

--- a/invenio_vocabularies/contrib/names/names.py
+++ b/invenio_vocabularies/contrib/names/names.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Vocabulary names."""
+
+from invenio_pidstore.providers.recordid_v2 import RecordIdProviderV2
+from invenio_records.systemfields import RelationsField
+from invenio_records_resources.factories.factory import RecordTypeFactory
+from invenio_records_resources.records.systemfields import PIDListRelation, \
+    PIDRelation
+
+from ...records.pidprovider import PIDProviderFactory
+from ...records.systemfields import BaseVocabularyPIDFieldContext
+from ...services.permissions import PermissionPolicy
+from ..affiliations.api import Affiliation
+from .config import NamesSearchOptions, service_components
+from .schema import NameSchema
+
+name_relations = RelationsField(
+    affiliations=PIDListRelation(
+        'affiliations',
+        attrs=['id', 'name'],
+        pid_field=Affiliation.pid,
+        cache_key='affiliations',
+    )
+)
+
+record_type = RecordTypeFactory(
+    "Name",
+    # Data layer
+    pid_field_kwargs={
+        "create": False,
+        "provider": RecordIdProviderV2,
+        "context_cls": BaseVocabularyPIDFieldContext,
+    },
+    schema_version="1.0.0",
+    schema_path="local://names/name-v1.0.0.json",
+    record_relations=name_relations,
+    # Service layer
+    service_schema=NameSchema,
+    search_options=NamesSearchOptions,
+    service_components=service_components,
+    permission_policy_cls=PermissionPolicy,
+    # Resource layer
+    endpoint_route='/names',
+)

--- a/invenio_vocabularies/contrib/names/resources.py
+++ b/invenio_vocabularies/contrib/names/resources.py
@@ -7,10 +7,10 @@
 # modify it under the terms of the MIT License; see LICENSE file for more
 # details.
 
-"""Affiliation vocabulary resources."""
+"""Names vocabulary resources."""
 
-from .affiliations import record_type
+from .names import record_type
 
-AffiliationsResourceConfig = record_type.resource_config_cls
+NamesResourceConfig = record_type.resource_config_cls
 
-AffiliationsResource = record_type.resource_cls
+NamesResource = record_type.resource_cls

--- a/invenio_vocabularies/contrib/names/schema.py
+++ b/invenio_vocabularies/contrib/names/schema.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Names schema."""
+
+from functools import partial
+
+from flask_babelex import lazy_gettext as _
+from invenio_records_resources.services.records.schema import BaseRecordSchema
+from marshmallow import Schema, ValidationError, fields, post_load, \
+    validates_schema
+from marshmallow_utils.fields import IdentifierSet, SanitizedUnicode
+from marshmallow_utils.schemas import IdentifierSchema
+
+from .config import names_schemes
+
+
+# FIXME: this is a dup from rdm-records, shall we add it in the aff vocab?
+class AffiliationSchema(Schema):
+    """Affiliation of a creator/contributor."""
+
+    id = SanitizedUnicode()
+    name = SanitizedUnicode()
+
+    @validates_schema
+    def validate_affiliation(self, data, **kwargs):
+        """Validates that either id either name are present."""
+        id_ = data.get("id")
+        name = data.get("name")
+        if id_:
+            data = {"id": id_}
+        elif name:
+            data = {"name": name}
+
+        if not id_ and not name:
+            raise ValidationError(
+                _("An existing id or a free text name must be present"),
+                "names.affiliations"
+            )
+
+
+class NameSchema(BaseRecordSchema):
+    """Service schema for names.
+
+    Note that this vocabulary is very different from the base vocabulary
+    so it does not inherit from it.
+    """
+
+    name = SanitizedUnicode()
+    given_name = SanitizedUnicode()
+    family_name = SanitizedUnicode()
+    identifiers = IdentifierSet(
+        fields.Nested(partial(
+            IdentifierSchema,
+            # It is intended to allow org schemes to be sent as personal
+            # and viceversa. This is a trade off learnt from running
+            # Zenodo in production.
+            allowed_schemes=names_schemes
+        ))
+    )
+    affiliations = fields.List(fields.Nested(AffiliationSchema))
+
+    @validates_schema
+    def validate_names(self, data, **kwargs):
+        """Validate names."""
+        can_compose = data.get('family_name') and data.get("given_name")
+        name = data.get("name")
+        if not can_compose and not name:
+            messages = [
+                _("name or family_name and given_name must be present.")
+            ]
+            raise ValidationError({
+                "family_name": messages
+            })
+
+    @post_load
+    def calculate_name(self, data, **kwargs):
+        """Update names for person.
+
+        Fill name from given_name and family_name if person.
+        """
+        family_name = data.get("family_name")
+        given_name = data.get("given_name")
+        if family_name and given_name:
+            data["name"] = f"{family_name}, {given_name}"
+
+        return data

--- a/invenio_vocabularies/contrib/names/schema.py
+++ b/invenio_vocabularies/contrib/names/schema.py
@@ -20,7 +20,6 @@ from marshmallow_utils.schemas import IdentifierSchema
 from .config import names_schemes
 
 
-# FIXME: this is a dup from rdm-records, shall we add it in the aff vocab?
 class AffiliationSchema(Schema):
     """Affiliation of a creator/contributor."""
 

--- a/invenio_vocabularies/contrib/names/services.py
+++ b/invenio_vocabularies/contrib/names/services.py
@@ -6,11 +6,10 @@
 # modify it under the terms of the MIT License; see LICENSE file for more
 # details.
 
-"""Names module."""
+"""Names services."""
 
-from .services import NamesService, NamesServiceConfig
+from .names import record_type
 
-__all__ = [
-    "NamesService",
-    "NamesServiceConfig",
-]
+NamesServiceConfig = record_type.service_config_cls
+
+NamesService = record_type.service_cls

--- a/tests/contrib/affiliations/test_affiliations_resource.py
+++ b/tests/contrib/affiliations/test_affiliations_resource.py
@@ -34,7 +34,7 @@ def example_affiliation(
     return aff
 
 
-def test_affiliations_invalid(client, h, prefix, affiliation_full_data):
+def test_affiliations_invalid(client, h, prefix):
     """Test invalid type."""
     # invalid type
     res = client.get(f"{prefix}/invalid", headers=h)

--- a/tests/contrib/names/conftest.py
+++ b/tests/contrib/names/conftest.py
@@ -14,6 +14,10 @@ fixtures are available.
 
 import pytest
 
+from invenio_vocabularies.contrib.affiliations.api import Affiliation
+from invenio_vocabularies.contrib.names.services import NamesService, \
+    NamesServiceConfig
+
 
 @pytest.fixture(scope="module")
 def extra_entry_points():
@@ -34,6 +38,22 @@ def extra_entry_points():
                 invenio_vocabularies.contrib.names.mappings",
         ]
     }
+
+
+@pytest.fixture(scope='module')
+def service():
+    """Names service object."""
+    return NamesService(config=NamesServiceConfig)
+
+
+@pytest.fixture()
+def example_affiliation(db):
+    """Example affiliation."""
+    aff = Affiliation.create({"id": "cern"})
+    Affiliation.pid.create(aff)
+    aff.commit()
+    db.session.commit()
+    return aff
 
 
 @pytest.fixture(scope="function")

--- a/tests/contrib/names/conftest.py
+++ b/tests/contrib/names/conftest.py
@@ -15,6 +15,8 @@ fixtures are available.
 import pytest
 
 from invenio_vocabularies.contrib.affiliations.api import Affiliation
+from invenio_vocabularies.contrib.names.resources import NamesResource, \
+    NamesResourceConfig
 from invenio_vocabularies.contrib.names.services import NamesService, \
     NamesServiceConfig
 
@@ -46,6 +48,12 @@ def service():
     return NamesService(config=NamesServiceConfig)
 
 
+@pytest.fixture(scope="module")
+def resource(service):
+    """Names resource object."""
+    return NamesResource(NamesResourceConfig, service)
+
+
 @pytest.fixture()
 def example_affiliation(db):
     """Example affiliation."""
@@ -67,6 +75,9 @@ def name_full_data():
             {
                 "identifier": "0000-0001-8135-3489",
                 "scheme": "orcid"
+            }, {
+                "identifier": "gnd:4079154-3",
+                "scheme": "gnd"
             }
         ],
         "affiliations": [
@@ -78,3 +89,15 @@ def name_full_data():
             }
         ]
     }
+
+
+@pytest.fixture(scope="module")
+def base_app(base_app, resource, service):
+    """Application factory fixture.
+
+    Registers affiliations' resource and service.
+    """
+    base_app.register_blueprint(resource.as_blueprint())
+    registry = base_app.extensions['invenio-records-resources'].registry
+    registry.register(service, service_id='names-service')
+    yield base_app

--- a/tests/contrib/names/conftest.py
+++ b/tests/contrib/names/conftest.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Pytest configuration.
+
+See https://pytest-invenio.readthedocs.io/ for documentation on which test
+fixtures are available.
+"""
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def extra_entry_points():
+    """Extra entry points to load the mock_module features."""
+    # affiliations are needed due to sysfield relation
+    return {
+        "invenio_db.models": [
+            "affiliations = invenio_vocabularies.contrib.affiliations.models",
+            "names = invenio_vocabularies.contrib.names.models",
+        ],
+        "invenio_jsonschemas.schemas": [
+            "affiliations = \
+                invenio_vocabularies.contrib.affiliations.jsonschemas",
+            "names = invenio_vocabularies.contrib.names.jsonschemas",
+        ],
+        "invenio_search.mappings": [
+            "names = \
+                invenio_vocabularies.contrib.names.mappings",
+        ]
+    }
+
+
+@pytest.fixture(scope="function")
+def name_full_data():
+    """Full name data."""
+    return {
+        "name": "Doe, John",
+        "given_name": "John",
+        "family_name": "Doe",
+        "identifiers": [
+            {
+                "identifier": "0000-0001-8135-3489",
+                "scheme": "orcid"
+            }
+        ],
+        "affiliations": [
+            {
+                "id": "cern"
+            },
+            {
+                "name": "CustomORG"
+            }
+        ]
+    }

--- a/tests/contrib/names/test_names_api.py
+++ b/tests/contrib/names/test_names_api.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Names API tests."""
+
+from functools import partial
+
+import pytest
+from invenio_indexer.api import RecordIndexer
+from invenio_search import current_search_client
+from jsonschema import ValidationError as SchemaValidationError
+
+from invenio_records.systemfields.relations.errors import InvalidRelationValue
+from invenio_vocabularies.contrib.affiliations.api import Affiliation
+from invenio_vocabularies.contrib.names.api import Name
+
+
+@pytest.fixture()
+def search_get():
+    """Get a document from an index."""
+    return partial(
+        current_search_client.get, Name.index._name, doc_type="_doc"
+    )
+
+
+@pytest.fixture()
+def indexer():
+    """Indexer instance with correct Record class."""
+    return RecordIndexer(
+        record_cls=Name,
+        record_to_index=lambda r: (r.__class__.index._name, "_doc"),
+    )
+
+
+@pytest.fixture()
+def example_affiliation(db):
+    """Example affiliation."""
+    aff = Affiliation.create({"id": "cern"})
+    Affiliation.pid.create(aff)
+    aff.commit()
+    db.session.commit()
+    return aff
+
+
+@pytest.fixture()
+def example_name(db, name_full_data, example_affiliation):
+    """Example name."""
+    name = Name.create(name_full_data)
+    Name.pid.create(name)
+    name.commit()
+    db.session.commit()
+    return name
+
+
+def test_name_schema_validation(app, db, example_name):
+    """Name schema validation."""
+    # valid data
+    name = example_name
+
+    assert name.schema == "local://names/name-v1.0.0.json"
+    assert name.pid
+    assert name.id
+
+    # invalid data
+    examples = [
+        # identifiers are objects of key/string.
+        {"name": "Doe, John", "identifiers": "0000-0001-8135-3489"},
+        {"name": "Doe, John", "identifiers": ["0000-0001-8135-3489"]},
+        {"name": "Doe, John", "identifiers": {"0000-0001-8135-3489"}},
+        # names must be a string
+        {"name": 123},
+        {"family_name": 123, "given_name": "John"},
+        {"family_name": "Doe", "given_name": 123},
+        # affiliations are objects of key/string.
+        {"name": "Doe, John", "affiliations": "cern"},
+        {"name": "Doe, John", "affiliations": ["cern"]},
+        {"name": "Doe, John", "affiliations": {"cern"}},
+    ]
+
+    for ex in examples:
+        pytest.raises(SchemaValidationError, Name.create, ex)
+
+    # test an affiliation that does not exist in the db
+    invalid_aff = {"name": "Doe, John", "affiliations": [{"id": "invalid"}]}
+    invalid_name = Name.create(invalid_aff)
+    pytest.raises(InvalidRelationValue, invalid_name.commit)
+
+
+def test_name_indexing(app, db, es, example_name, indexer, search_get):
+    """Test indexing of a name."""
+    # Index document in ES
+    assert indexer.index(example_name)["result"] == "created"
+
+    # Retrieve document from ES
+    data = search_get(id=example_name.id)
+
+    # Loads the ES data and compare
+    name = Name.loads(data["_source"])
+    assert name == example_name
+    assert name.id == example_name.id
+    assert name.revision_id == example_name.revision_id
+    assert name.created == example_name.created
+    assert name.updated == example_name.updated
+
+
+def test_name_pid(app, db, example_name):
+    """Test name pid creation."""
+    name = example_name
+
+    assert name.pid.pid_value
+    assert name.pid.pid_type == "recid"
+    # FIXME: add resolution test when the pid_type is fixed

--- a/tests/contrib/names/test_names_api.py
+++ b/tests/contrib/names/test_names_api.py
@@ -16,7 +16,6 @@ from invenio_search import current_search_client
 from jsonschema import ValidationError as SchemaValidationError
 
 from invenio_records.systemfields.relations.errors import InvalidRelationValue
-from invenio_vocabularies.contrib.affiliations.api import Affiliation
 from invenio_vocabularies.contrib.names.api import Name
 
 
@@ -35,16 +34,6 @@ def indexer():
         record_cls=Name,
         record_to_index=lambda r: (r.__class__.index._name, "_doc"),
     )
-
-
-@pytest.fixture()
-def example_affiliation(db):
-    """Example affiliation."""
-    aff = Affiliation.create({"id": "cern"})
-    Affiliation.pid.create(aff)
-    aff.commit()
-    db.session.commit()
-    return aff
 
 
 @pytest.fixture()

--- a/tests/contrib/names/test_names_api.py
+++ b/tests/contrib/names/test_names_api.py
@@ -12,10 +12,10 @@ from functools import partial
 
 import pytest
 from invenio_indexer.api import RecordIndexer
+from invenio_records.systemfields.relations.errors import InvalidRelationValue
 from invenio_search import current_search_client
 from jsonschema import ValidationError as SchemaValidationError
 
-from invenio_records.systemfields.relations.errors import InvalidRelationValue
 from invenio_vocabularies.contrib.names.api import Name
 
 

--- a/tests/contrib/names/test_names_jsonschema.py
+++ b/tests/contrib/names/test_names_jsonschema.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Names JSONSchema tests."""
+
+import pytest
+from jsonschema.exceptions import ValidationError
+
+from invenio_vocabularies.contrib.names.api import Name
+
+
+@pytest.fixture(scope="module")
+def schema():
+    """Returns the schema location."""
+    return "local://names/name-v1.0.0.json"
+
+
+def validates(data):
+    """Validates names data."""
+    Name(data).validate()
+
+    return True
+
+
+def fails(data):
+    """Validates names data."""
+    pytest.raises(ValidationError, validates, data)
+    return True
+
+
+def test_valid_full(appctx, schema):
+    data = {
+        "$schema": schema,
+        "name": "Doe, John",
+        "given_name": "John",
+        "family_name": "Doe",
+        "identifiers": [
+            {
+                "identifier": "0000-0001-8135-3489",
+                "scheme": "orcid"
+            }
+        ],
+        "affiliations": [
+            {
+                "id": "cern"
+            },
+            {
+                "name": "CustomORG"
+            }
+        ]
+    }
+    assert validates(data)
+
+
+def test_valid_empty(appctx, schema):
+    # check there are no requirements at JSONSchema level
+    data = {
+        "$schema": schema
+    }
+
+    assert validates(data)
+
+
+# only acronym and name are defined by the affiliation schema
+# the rest are inherited and should be tested elsewhere
+
+def test_fails_name_identifiers(appctx, schema):
+    # string
+    data = {
+        "$schema": schema,
+        "identifiers": "0000-0001-8135-3489"
+    }
+
+    assert fails(data)
+
+    # dict
+    data = {
+        "$schema": schema,
+        "identifiers": {
+            "identifier": "0000-0001-8135-3489",
+            "scheme": "orcid"
+        }
+    }
+
+    assert fails(data)
+
+
+def test_fails_name_affiliations(appctx, schema):
+    # string, comma separated list
+    data = {
+        "$schema": schema,
+        "affiliations": "cern, CustomORG"
+    }
+
+    assert fails(data)
+
+    # dict
+    data = {
+        "$schema": schema,
+        "affiliations": {
+            "id": "cern",
+            "name": "CustomORG"
+        }
+    }
+
+    assert fails(data)

--- a/tests/contrib/names/test_names_resource.py
+++ b/tests/contrib/names/test_names_resource.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2021 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Test the name vocabulary resource."""
+
+import json
+from copy import deepcopy
+
+import pytest
+
+from invenio_vocabularies.contrib.names.api import Name
+
+
+@pytest.fixture(scope="module")
+def prefix():
+    """API prefix."""
+    return "names"
+
+
+@pytest.fixture()
+def example_name(
+    app, db, es_clear, identity, service, name_full_data, example_affiliation
+):
+    """Example affiliation."""
+    name = service.create(identity, name_full_data)
+    Name.index.refresh()  # Refresh the index
+
+    return name
+
+
+def test_names_invalid(client, h, prefix):
+    """Test invalid type."""
+    # invalid type
+    res = client.get(f"{prefix}/invalid", headers=h)
+    assert res.status_code == 404
+
+
+def test_names_forbidden(client, h, prefix, example_name, name_full_data):
+    """Test invalid type."""
+    # invalid type
+    res = client.post(
+        f"{prefix}", headers=h, data=json.dumps(name_full_data))
+    assert res.status_code == 403
+
+    res = client.put(
+        f"{prefix}/{example_name.id}",
+        headers=h,
+        data=json.dumps(name_full_data)
+    )
+    assert res.status_code == 403
+
+    res = client.delete(f"{prefix}/{example_name.id}")
+    assert res.status_code == 403
+
+
+def test_names_get(client, example_name, h, prefix):
+    """Test the endpoint to retrieve a single item."""
+    id_ = example_name.id
+
+    res = client.get(f"{prefix}/{id_}", headers=h)
+    assert res.status_code == 200
+    assert res.json["id"] == id_
+    # Test links
+    assert res.json["links"] == {
+        "self": f"https://127.0.0.1:5000/api/names/{example_name.id}"
+    }
+
+
+def test_names_search(client, example_name, h, prefix):
+    """Test a successful search."""
+    res = client.get(prefix, headers=h)
+
+    assert res.status_code == 200
+    assert res.json["hits"]["total"] == 1
+    assert res.json["sortBy"] == "name"

--- a/tests/contrib/names/test_names_schema.py
+++ b/tests/contrib/names/test_names_schema.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Names Marshmallow schema tests."""
+
+import pytest
+from marshmallow import ValidationError
+
+from invenio_vocabularies.contrib.names.schema import NameSchema
+
+
+def test_valid_full(app, name_full_data):
+    loaded = NameSchema().load(name_full_data)
+    assert name_full_data == loaded
+
+
+def test_valid_minimal(app):
+    data = {
+        "name": "Doe, John",
+    }
+    loaded = NameSchema().load(data)
+    assert data == loaded
+
+    data = {
+        "family_name": "Doe",
+        "given_name": "John"
+    }
+    loaded = NameSchema().load(data)
+    data["name"] = 'Doe, John'  # it will be calculated and included
+    assert data == loaded
+
+
+def test_invalid_no_names(app):
+    # no name
+    invalid = {
+        "identifiers": [
+            {
+                "identifier": "0000-0001-8135-3489",
+                "scheme": "orcid"
+            }
+        ],
+        "affiliations": [
+            {"id": "cern"},
+            {"name": "CustomORG"}
+        ]
+    }
+    with pytest.raises(ValidationError):
+        data = NameSchema().load(invalid)
+
+    # only given name
+    invalid["given_name"] = "John",
+
+    with pytest.raises(ValidationError):
+        data = NameSchema().load(invalid)
+
+    # only family name
+    invalid["family_name"] = "Doe",
+    invalid.pop("given_name")
+
+    with pytest.raises(ValidationError):
+        data = NameSchema().load(invalid)

--- a/tests/contrib/names/test_names_service.py
+++ b/tests/contrib/names/test_names_service.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2021 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Test the names vocabulary service."""
+
+import pytest
+from invenio_pidstore.errors import PIDAlreadyExists, PIDDeletedError
+from marshmallow.exceptions import ValidationError
+from sqlalchemy.exc import IntegrityError
+
+from invenio_vocabularies.contrib.names.api import Name
+
+
+def test_simple_flow(
+    app, db, service, identity, name_full_data, example_affiliation
+):
+    """Test a simple vocabulary service flow."""
+    # Create it
+    item = service.create(identity, name_full_data)
+    id_ = item.id
+
+    for k, v in name_full_data.items():
+        assert item.data[k] == v
+
+    # Read it
+    read_item = service.read(id_, identity)
+    assert item.id == read_item.id
+    assert item.data == read_item.data
+
+    # Refresh index to make changes live.
+    Name.index.refresh()
+
+    # Search it
+    res = service.search(
+        identity, q=f"id:{id_}", size=25, page=1)
+    assert res.total == 1
+    assert list(res.hits)[0] == read_item.data
+
+    # Update it
+    data = read_item.data
+    data["given_name"] = "Jane"
+    update_item = service.update(id_, identity, data)
+    assert item.id == update_item.id
+    assert update_item['given_name'] == 'Jane'
+    assert update_item['name'] == "Doe, Jane"  # automatic update
+
+    # Delete it
+    assert service.delete(id_, identity)
+
+    # Refresh to make changes live
+    Name.index.refresh()
+
+    # Fail to retrieve it
+    # - db
+    pytest.raises(PIDDeletedError, service.read, id_, identity)
+    # - search
+    res = service.search(identity, q=f"id:{id_}", size=25, page=1)
+    assert res.total == 0
+
+
+def test_extra_fields(app, db, service, identity, name_full_data):
+    """Extra fields in data should fail."""
+    name_full_data['invalid'] = 1
+    pytest.raises(ValidationError, service.create, identity, name_full_data)

--- a/tests/contrib/subjects/test_subjects_resource.py
+++ b/tests/contrib/subjects/test_subjects_resource.py
@@ -48,7 +48,7 @@ def test_get(client, h, prefix, example_subject):
     assert res.status_code == 200
 
 
-def test_get_invalid(client, h, prefix, example_subject):
+def test_get_invalid(client, h, prefix):
     res = client.get(f"{prefix}/invalid", headers=h)
     assert res.status_code == 404
 

--- a/tests/test_alembic.py
+++ b/tests/test_alembic.py
@@ -42,6 +42,7 @@ def test_alembic(app, database):
     # Specific vocabularies models
     assert 'subject_metadata' in tables
     assert 'affiliation_metadata' in tables
+    assert 'name_metadata' in tables
 
     # Check that Alembic agrees that there's no further tables to create.
     assert_alembic(ext.alembic, ['mock_metadata'])


### PR DESCRIPTION
- requires https://github.com/inveniosoftware/invenio-records-resources/issues/289
- closes https://github.com/inveniosoftware/invenio-vocabularies/issues/84
- triggers https://github.com/inveniosoftware/invenio-vocabularies/issues/98

**Notes for the reviewers**
- The PID provider posses some complexities, but in order to unlock the loading/cli work and merge the vocabulary, work on the provider/pids will be done as a separate issue in https://github.com/inveniosoftware/invenio-vocabularies/issues/94

