### PR TITLE
contrib: relation schemas

### DIFF
--- a/invenio_vocabularies/contrib/affiliations/schema.py
+++ b/invenio_vocabularies/contrib/affiliations/schema.py
@@ -10,7 +10,8 @@
 
 from functools import partial
 
-from marshmallow import fields
+from flask_babelex import lazy_gettext as _
+from marshmallow import Schema, ValidationError, fields, validates_schema
 from marshmallow_utils.fields import IdentifierSet, SanitizedUnicode
 from marshmallow_utils.schemas import IdentifierSchema
 
@@ -30,3 +31,26 @@ class AffiliationSchema(BaseVocabularySchema):
         )
     ))
     name = SanitizedUnicode(required=True)
+
+
+class AffiliationRelationSchema(Schema):
+    """Schema to define an optional affialiation relation in another schema."""
+
+    id = SanitizedUnicode()
+    name = SanitizedUnicode()
+
+    @validates_schema
+    def validate_affiliation(self, data, **kwargs):
+        """Validates that either id either name are present."""
+        id_ = data.get("id")
+        name = data.get("name")
+        if id_:
+            data = {"id": id_}
+        elif name:
+            data = {"name": name}
+
+        if not id_ and not name:
+            raise ValidationError(
+                _("An existing id or a free text name must be present"),
+                "affiliations"
+            )

--- a/invenio_vocabularies/contrib/awards/__init__.py
+++ b/invenio_vocabularies/contrib/awards/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Awards vocabulary."""

--- a/invenio_vocabularies/contrib/awards/schema.py
+++ b/invenio_vocabularies/contrib/awards/schema.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Awards schema."""
+
+from flask_babelex import lazy_gettext as _
+from marshmallow import Schema, ValidationError, fields, validate, \
+    validates_schema
+from marshmallow_utils.fields import SanitizedUnicode
+
+from ..funders.schema import FunderRelationSchema
+
+
+class AwardRelationSchema(Schema):
+    """Award schema."""
+
+    title = SanitizedUnicode(
+        required=True,
+        validate=validate.Length(min=1, error=_('Title cannot be blank.'))
+    )
+    number = SanitizedUnicode(
+        required=True,
+        validate=validate.Length(min=1, error=_('Number cannot be blank.'))
+    )
+    scheme = SanitizedUnicode()
+    identifier = SanitizedUnicode()
+
+
+class FundingRelationSchema(Schema):
+    """Funding schema."""
+
+    funder = fields.Nested(FunderRelationSchema)
+    award = fields.Nested(AwardRelationSchema)
+
+    @validates_schema
+    def validate_data(self, data, **kwargs):
+        """Validate either funder or award is present."""
+        funder = data.get('funder')
+        award = data.get('award')
+        if not funder and not award:
+            raise ValidationError(
+                {"funding": _("At least award or funder should be present.")})

--- a/invenio_vocabularies/contrib/funders/__init__.py
+++ b/invenio_vocabularies/contrib/funders/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Funders vocabulary."""

--- a/invenio_vocabularies/contrib/funders/schema.py
+++ b/invenio_vocabularies/contrib/funders/schema.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Funders schema."""
+
+from flask_babelex import lazy_gettext as _
+from marshmallow import Schema, fields, validate
+from marshmallow_utils.fields import SanitizedUnicode
+
+
+class FunderRelationSchema(Schema):
+    """Funder schema."""
+
+    name = SanitizedUnicode(
+        required=True,
+        validate=validate.Length(min=1, error=_('Name cannot be blank.'))
+    )
+    scheme = SanitizedUnicode()
+    identifier = SanitizedUnicode()

--- a/invenio_vocabularies/version.py
+++ b/invenio_vocabularies/version.py
@@ -13,4 +13,4 @@ This file is imported by ``invenio_vocabularies.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.1"
+__version__ = "0.9.2"

--- a/tests/contrib/affiliations/test_affiliations_schema.py
+++ b/tests/contrib/affiliations/test_affiliations_schema.py
@@ -11,7 +11,8 @@
 import pytest
 from marshmallow import ValidationError
 
-from invenio_vocabularies.contrib.affiliations.schema import AffiliationSchema
+from invenio_vocabularies.contrib.affiliations.schema import \
+    AffiliationRelationSchema, AffiliationSchema
 
 
 def test_valid_full(app, affiliation_full_data):
@@ -41,3 +42,34 @@ def test_invalid_no_name(app):
     }
     with pytest.raises(ValidationError):
         data = AffiliationSchema().load(invalid)
+
+
+#
+# AffiliationRelationSchema
+#
+def test_valid_id():
+    valid_id = {
+        "id": "test",
+    }
+    assert valid_id == AffiliationRelationSchema().load(valid_id)
+
+
+def test_valid_name():
+    valid_name = {
+        "name": "Entity One"
+    }
+    assert valid_name == AffiliationRelationSchema().load(valid_name)
+
+
+def test_valid_both_id_name():
+    valid_id_name = {
+        "id": "test",
+        "name": "Entity One"
+    }
+    assert valid_id_name == AffiliationRelationSchema().load(valid_id_name)
+
+
+def test_invalid_empty():
+    invalid_empty = {}
+    with pytest.raises(ValidationError):
+        data = AffiliationRelationSchema().load(invalid_empty)

--- a/tests/contrib/awards/test_awards_schema.py
+++ b/tests/contrib/awards/test_awards_schema.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# Invenio-RDM-Records is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Test award schema."""
+
+import pytest
+from marshmallow import ValidationError
+
+from invenio_vocabularies.contrib.awards.schema import AwardRelationSchema, \
+    FundingRelationSchema
+
+
+#
+# AwardRelationSchema
+#
+def test_valid_full():
+    valid_full = {
+        "title": "Some award",
+        "number": "100",
+        "identifier": "10.5281/zenodo.9999999",
+        "scheme": "doi"
+    }
+    assert valid_full == AwardRelationSchema().load(valid_full)
+
+
+def test_valid_minimal():
+    valid_minimal = {
+        "title": "Some award",
+        "number": "100",
+    }
+    assert valid_minimal == AwardRelationSchema().load(valid_minimal)
+
+
+def test_invalid_no_title():
+    invalid_no_title = {
+        "number": "100",
+        "identifier": "10.5281/zenodo.9999999",
+        "scheme": "doi"
+    }
+    with pytest.raises(ValidationError):
+        data = AwardRelationSchema().load(invalid_no_title)
+
+
+def test_invalid_no_number():
+    invalid_no_number = {
+        "title": "Some award",
+        "identifier": "10.5281/zenodo.9999999",
+        "scheme": "doi"
+    }
+    with pytest.raises(ValidationError):
+        data = AwardRelationSchema().load(invalid_no_number)
+
+
+#
+# FundingRelationSchema
+#
+
+AWARD = {
+    "title": "Some award",
+    "number": "100",
+    "identifier": "10.5281/zenodo.9999999",
+    "scheme": "doi"
+}
+
+FUNDER = {
+    "name": "Someone",
+    "identifier": "10.5281/zenodo.9999999",
+    "scheme": "doi"
+}
+
+
+def test_valid_award_funding():
+    valid_funding = {
+        "award": AWARD
+    }
+    assert valid_funding == FundingRelationSchema().load(valid_funding)
+
+
+def test_valid_funder_funding():
+    valid_funding = {
+        "funder": FUNDER
+    }
+    assert valid_funding == FundingRelationSchema().load(valid_funding)
+
+
+def test_valid_award_funder_funding():
+    valid_funding = {
+        "funder": FUNDER,
+        "award": AWARD
+    }
+    assert valid_funding == FundingRelationSchema().load(valid_funding)
+
+
+def test_invalid_empty_funding():
+    invalid_funding = {}
+    with pytest.raises(ValidationError):
+        data = FundingRelationSchema().load(invalid_funding)

--- a/tests/contrib/funders/test_funders_schema.py
+++ b/tests/contrib/funders/test_funders_schema.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# Invenio-RDM-Records is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Test funder schema."""
+
+import pytest
+from marshmallow import ValidationError
+
+from invenio_vocabularies.contrib.funders.schema import FunderRelationSchema
+
+
+def test_valid_full():
+    valid_full = {
+        "name": "Someone",
+        "identifier": "10.5281/zenodo.9999999",
+        "scheme": "doi"
+    }
+    assert valid_full == FunderRelationSchema().load(valid_full)
+
+
+def test_valid_minimal():
+    valid_minimal = {
+        "name": "Someone"
+    }
+    assert valid_minimal == FunderRelationSchema().load(valid_minimal)
+
+
+def test_invalid_no_name():
+    invalid_no_name = {
+        "identifier": "10.5281/zenodo.9999999",
+        "scheme": "doi"
+    }
+    with pytest.raises(ValidationError):
+        data = FunderRelationSchema().load(invalid_no_name)


### PR DESCRIPTION
* Moving schemas from Invenio-RDM-Records to Invenio-Vocabularies so
  that a dependency among Invenio-RDM-Records and Invenio-Communities
  can be broken.