### PR TITLE
adds transformer logic and CLI

### DIFF
--- a/invenio_vocabularies/cli.py
+++ b/invenio_vocabularies/cli.py
@@ -7,119 +7,28 @@
 # modify it under the terms of the MIT License; see LICENSE file for more
 # details.
 
-"""Commands to create and manage vocabulary."""
+"""Commands to create and manage vocabularies."""
 
-import csv
-from os.path import dirname, join
+from copy import deepcopy
 
 import click
+import yaml
 from flask.cli import with_appcontext
-from flask_principal import Identity
-from invenio_access import any_user
-from invenio_db import db
 
-from invenio_vocabularies.contrib.subjects.subjects import \
-    record_type as subject_record_type
-from invenio_vocabularies.records.models import VocabularyType
-from invenio_vocabularies.services.service import VocabulariesService
-
-data_directory = join(dirname(__file__), "data")
+from .contrib.names.datastreams import DATASTREAM_CONFIG as names_ds_config
+from .datastreams import DataStreamFactory
 
 
-def get_available_vocabularies():
-    """Specify the available vocabularies."""
-    return {
-        "licenses": {
-            "path": join(data_directory, "licenses.csv"),
-        },
-        "subjects": {
-            "path": join(data_directory, "subjects.csv"),
-            "specific": _create_subjects_vocabulary,
-        },
-    }
+def get_config_for_ds(vocabulary, filepath=None, origin=None):
+    """Calculates the configuration for a Data Stream."""
+    if vocabulary == "names":  # FIXME: turn into a proper factory
+        config = deepcopy(names_ds_config)
+        if filepath:
+            config = yaml.load(filepath).get(vocabulary)
+        if origin:
+            config["reader"]["args"]["origin"] = origin
 
-
-def _load_csv_data(path):
-    with open(path) as f:
-        reader = csv.DictReader(f, skipinitialspace=True)
-        dicts = [row for row in reader]
-        return dicts
-
-
-def _create_subjects_vocabulary(vocabulary_type_name, source_path):
-    identity = Identity(1)
-    identity.provides.add(any_user)
-    service = subject_record_type.service_cls()
-
-    rows = _load_csv_data(source_path)
-
-    records = []
-    for row in rows:
-        metadata = {
-            "title": row["title"],
-            "term": row["id"],
-            "identifier": row["id"],
-            "scheme": row["scheme"],
-        }
-
-        record = service.create(
-            identity=identity,
-            data={
-                "metadata": metadata,
-            },
-        )
-
-        records.append(record)
-
-    return records
-
-
-def _create_vocabulary(vocabulary_type_name, source_path):
-    identity = Identity(1)
-    identity.provides.add(any_user)
-    service = VocabulariesService()
-
-    # Load data
-    rows = _load_csv_data(source_path)
-
-    # Create vocabulary type
-    vocabulary_type = VocabularyType(name=vocabulary_type_name)
-    db.session.add(vocabulary_type)
-    db.session.commit()
-
-    i18n = ["title", "description"]  # Attributes with i18n support
-    other = ["icon"]  # Other top-level attributes
-
-    default_language = "en"  # Static (dependent on the files)
-
-    metadata = {"title": {}, "description": {}, "props": {}}
-
-    records = []
-    for row in rows:
-        for attribute in row:
-            value = row[attribute]
-            if attribute in i18n:
-                metadata[attribute][default_language] = value
-            elif any(map(lambda s: value.startswith(s + "_"), i18n)):
-                [prefix_attr, language] = attribute.split("_", 1)
-                metadata[prefix_attr][language] = value
-            elif attribute in other:
-                metadata[attribute] = value
-            else:
-                metadata["props"][attribute] = value
-
-        # Create record
-        record = service.create(
-            identity=identity,
-            data={
-                "metadata": metadata,
-                "vocabulary_type_id": vocabulary_type.id,
-            },
-        )
-
-        records.append(record)
-
-    return records
+        return config
 
 
 @click.group()
@@ -128,13 +37,53 @@ def vocabularies():
     pass
 
 
+def _import_vocab(vocabulary, filepath=None, origin=None, num_samples=None):
+    """Import a vocabulary."""
+    config = get_config_for_ds(vocabulary, filepath, origin)
+    ds = DataStreamFactory.create(
+        reader_config=config["reader"],
+        transformers_config=config.get("transformers"),
+        writers_config=config["writers"],
+    )
+
+    success, errored = 0, 0
+    left = num_samples or -1
+    for result in ds.process():
+        left = left - 1
+        if left == 0:
+            click.secho(f"Number of samples reached {num_samples}", fg="green")
+            break
+        if result.errors:
+            for err in result.errors:
+                click.secho(err, fg="red")
+            errored += 1
+        else:
+            success += 1
+
+    return success, errored
+
+
 @vocabularies.command(name="import")
-@click.argument(
-    "vocabulary_types",
-    nargs=-1,
-    type=click.Choice([v for v in get_available_vocabularies()]),
-)
+@click.option("-v", "--vocabulary", type=click.STRING, required=True)
+@click.option("-f", "--filepath", type=click.STRING)
+@click.option("-o", "--origin", type=click.STRING)
+@click.option("-n", "--num-samples", type=click.INT)
 @with_appcontext
-def load(vocabulary_types):
-    """Index CSV-based vocabularies in Elasticsearch."""
-    click.secho("Temporarily disabled", color="red")
+def import_vocab(vocabulary, filepath=None, origin=None, num_samples=None):
+    """Import a vocabulary."""
+    if not filepath and not origin:
+        click.secho("One of --filepath or --origin must be present", fg="red")
+        exit(1)
+
+    success, errored = _import_vocab(vocabulary, filepath, origin, num_samples)
+    total = success + errored
+
+    color = "green"
+    if errored:
+        color = "yellow" if success else "red"
+
+    click.secho(
+        f"Vocabulary {vocabulary} loaded. Total items {total}. \n"
+        f"{success} items succeeded, {errored} contained errors.",
+        fg=color
+    )

--- a/invenio_vocabularies/config.py
+++ b/invenio_vocabularies/config.py
@@ -12,6 +12,9 @@
 import idutils
 from flask_babelex import lazy_gettext as _
 
+from .datastreams.readers import TarReader, YamlReader
+from .datastreams.transformers import XMLTransformer
+from .datastreams.writers import ServiceWriter
 from .resources.resource import VocabulariesResourceConfig
 from .services.service import VocabulariesServiceConfig
 
@@ -54,3 +57,19 @@ VOCABULARIES_NAMES_SCHEMES = {
     }
 }
 """Names allowed identifier schemes."""
+
+VOCABULARIES_DATASTREAM_READERS = {
+    "tar": TarReader,
+    "yaml": YamlReader,
+}
+"""Data Streams readers."""
+
+VOCABULARIES_DATASTREAM_TRANSFORMERS = {
+    "xml": XMLTransformer,
+}
+"""Data Streams transformers."""
+
+VOCABULARIES_DATASTREAM_WRITERS = {
+    "service": ServiceWriter
+}
+"""Data Streams writers."""

--- a/invenio_vocabularies/config.py
+++ b/invenio_vocabularies/config.py
@@ -14,7 +14,7 @@ from flask_babelex import lazy_gettext as _
 
 from .datastreams.readers import TarReader, YamlReader
 from .datastreams.transformers import XMLTransformer
-from .datastreams.writers import ServiceWriter
+from .datastreams.writers import ServiceWriter, YamlWriter
 from .resources.resource import VocabulariesResourceConfig
 from .services.service import VocabulariesServiceConfig
 
@@ -70,6 +70,7 @@ VOCABULARIES_DATASTREAM_TRANSFORMERS = {
 """Data Streams transformers."""
 
 VOCABULARIES_DATASTREAM_WRITERS = {
-    "service": ServiceWriter
+    "service": ServiceWriter,
+    "yaml": YamlWriter,
 }
 """Data Streams writers."""

--- a/invenio_vocabularies/contrib/names/datastreams.py
+++ b/invenio_vocabularies/contrib/names/datastreams.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Names datastreams, transformers, writers and readers."""
+
+from invenio_access.permissions import system_identity
+from invenio_records.dictutils import dict_lookup
+
+from ...datastreams.errors import TransformerError
+from ...datastreams.transformers import XMLTransformer
+
+
+class OrcidXMLTransformer(XMLTransformer):
+    """ORCiD XML Transfomer."""
+
+    def apply(self, entry, **kwargs):
+        """Applies the transformation to the entry."""
+        xml_tree = self._xml_to_etree(entry)
+        researcher = self._etree_to_dict(xml_tree)
+        record = researcher["html"]["body"].get("record")
+
+        if not record:
+            raise TransformerError(f"Record not found in ORCiD entry.")
+
+        person = record["person"]
+        orcid_id = record["orcid-identifier"]["uri"]
+
+        name = person.get("name")
+        if name is None:
+            raise TransformerError(f"Name not found in ORCiD entry.")
+
+        entry = {
+            "given_name": name.get("given-names"),
+            "family_name": name.get("family-name"),
+            "identifiers": [{"scheme": "orcid", "identifier": orcid_id}],
+            "affiliations": [],
+        }
+
+        try:
+            affiliation = dict_lookup(
+                record,
+                "activities-summary.employments.affiliation-group"
+                ".employment-summary.organization.name",
+            )
+            entry["affiliations"].append({"name": affiliation})
+        except Exception:
+            pass
+
+        return entry
+
+
+VOCABULARIES_DATASTREAM_TRANSFORMERS = {
+    "orcid-xml": OrcidXMLTransformer,
+}
+"""ORCiD Data Streams transformers."""
+
+DATASTREAM_CONFIG = {
+    "reader": {
+        "type": "tar",
+        "args": {
+            "regex": ".xml$",
+        }
+    },
+    "transformers": [
+        {"type": "orcid-xml"}
+    ],
+    "writers": [{
+        "type": "service",
+        "args": {
+            "service_or_name": "rdm-names",
+            "identity": system_identity,
+        }
+    }],
+}
+"""ORCiD Data Stream configuration.
+
+An origin is required for the reader.
+"""

--- a/invenio_vocabularies/contrib/names/names.py
+++ b/invenio_vocabularies/contrib/names/names.py
@@ -11,8 +11,7 @@
 from invenio_pidstore.providers.recordid_v2 import RecordIdProviderV2
 from invenio_records.systemfields import RelationsField
 from invenio_records_resources.factories.factory import RecordTypeFactory
-from invenio_records_resources.records.systemfields import PIDListRelation, \
-    PIDRelation
+from invenio_records_resources.records.systemfields import PIDListRelation
 
 from ...records.pidprovider import PIDProviderFactory
 from ...records.systemfields import BaseVocabularyPIDFieldContext

--- a/invenio_vocabularies/datastreams/__init__.py
+++ b/invenio_vocabularies/datastreams/__init__.py
@@ -7,3 +7,11 @@
 # details.
 
 """Datastreams module."""
+
+from .datastreams import BaseDataStream
+from .factories import DataStreamFactory
+
+__all__ = (
+    "BaseDataStream",
+    "DataStreamFactory",
+)

--- a/invenio_vocabularies/datastreams/errors.py
+++ b/invenio_vocabularies/datastreams/errors.py
@@ -9,6 +9,10 @@
 """Datastream errors."""
 
 
+class ReaderError(Exception):
+    """Transformer application exception."""
+
+
 class TransformerError(Exception):
     """Transformer application exception."""
 

--- a/invenio_vocabularies/datastreams/factories.py
+++ b/invenio_vocabularies/datastreams/factories.py
@@ -46,21 +46,21 @@ class WriterFactory(BaseFactory, OptionsConfigMixin):
     """Writer factory."""
 
     FACTORY_NAME = "Writer"
-    CONFIG_VAR = "VOCABULARIES_DATASOURCE_WRITERS"
+    CONFIG_VAR = "VOCABULARIES_DATASTREAM_WRITERS"
 
 
 class ReaderFactory(BaseFactory, OptionsConfigMixin):
     """Reader factory."""
 
     FACTORY_NAME = "Reader"
-    CONFIG_VAR = "VOCABULARIES_DATASOURCE_READERS"
+    CONFIG_VAR = "VOCABULARIES_DATASTREAM_READERS"
 
 
 class TransformerFactory(BaseFactory, OptionsConfigMixin):
     """Transformer factory."""
 
     FACTORY_NAME = "Transformer"
-    CONFIG_VAR = "VOCABULARIES_DATASOURCE_TRANSFORMERS"
+    CONFIG_VAR = "VOCABULARIES_DATASTREAM_TRANSFORMERS"
 
 
 class DataStreamFactory:

--- a/invenio_vocabularies/datastreams/transformers.py
+++ b/invenio_vocabularies/datastreams/transformers.py
@@ -8,6 +8,10 @@
 
 """Transformers module."""
 
+from collections import defaultdict
+
+from lxml import etree
+
 
 class BaseTransformer:
     """Base transformer."""
@@ -23,3 +27,35 @@ class BaseTransformer:
                   raises TransformerError in case of errors.
         """
         pass
+
+
+class XMLTransformer(BaseTransformer):
+    """XML transformer."""
+
+    @classmethod
+    def _xml_to_etree(cls, xml):
+        """Converts XML to a lxml etree."""
+        return etree.HTML(xml)
+
+    @classmethod
+    def _etree_to_dict(cls, tree):
+        d = {tree.tag: {} if tree.attrib else None}
+        children = list(tree)
+        if children:
+            dd = defaultdict(list)
+            for dc in map(cls._etree_to_dict, children):
+                for k, v in dc.items():
+                    dd[k].append(v)
+            d = {tree.tag: {k: v[0] if len(v) == 1 else v
+                            for k, v in dd.items()}}
+        if tree.attrib:
+            d[tree.tag].update(('@' + k, v)
+                               for k, v in tree.attrib.items())
+        if tree.text:
+            text = tree.text.strip()
+            if children or tree.attrib:
+                if text:
+                    d[tree.tag]['#text'] = text
+            else:
+                d[tree.tag] = text
+        return d

--- a/invenio_vocabularies/datastreams/writers.py
+++ b/invenio_vocabularies/datastreams/writers.py
@@ -8,6 +8,9 @@
 
 """Writers module."""
 
+from pathlib import Path
+
+import yaml
 from invenio_records_resources.proxies import current_service_registry
 from marshmallow import ValidationError
 
@@ -59,5 +62,28 @@ class ServiceWriter(BaseWriter):
             )
         if result.errors:
             raise WriterError(result.errors)
+
+        return result
+
+
+class YamlWriter(BaseWriter):
+    """Writes the entries to a YAML file."""
+
+    def __init__(self, filepath, *args, **kwargs):
+        """Constructor.
+
+        :param filepath: path of the output file.
+        """
+        self._filepath = Path(filepath)
+
+        super().__init__(*args, **kwargs)
+
+    def write(self, entry, *args, **kwargs):
+        """Writes the input entry using a given service."""
+        with open(self._filepath, 'a') as file:
+            # made into array for safer append
+            # will always read array (good for reader)
+            yaml.safe_dump([entry], file)
+            result = StreamResult(entry=entry)
 
         return result

--- a/invenio_vocabularies/fixtures.py
+++ b/invenio_vocabularies/fixtures.py
@@ -9,8 +9,10 @@
 """Fixtures module."""
 
 import yaml
+from invenio_access.permissions import system_identity
 
-from .datastreams.factories import DataStreamFactory, WriterFactory
+from .datastreams.factories import DataStreamFactory
+from .proxies import current_service
 
 
 class BaseFixture:
@@ -20,11 +22,8 @@ class BaseFixture:
         """Constructor."""
         self._filepath = filepath
 
-    # potential `ignore` and `force` arguments to support updating entries
-    # TODO: bulk writting
     def _load_vocabulary(self, config, delay=True, **kwargs):
         """Given an entry from the vocabularies.yaml file, load its content."""
-        # TODO: write with delay (tasks encapsulation needed)
         datastream = DataStreamFactory.create(
             reader_config=config["reader"],
             transformers_config=config.get("transformers"),
@@ -38,12 +37,10 @@ class BaseFixture:
 
         return errors
 
-    # TODO: support vocabularies with schemes (subvocabs)
     def _create_vocabulary(self, id_, pid_type, *args, **kwargs):
         """Creates a vocabulary."""
-        pass
+        return current_service.create_type(system_identity, id_, pid_type)
 
-    # TODO: support bulk import (e.g. db commit per item + bulk indexing)
     def load(self, *args, **kwargs):
         """Return content of vocabularies file."""
         with open(self._filepath) as f:

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,8 @@ setup_requires = [
 install_requires = [
     "invenio-records-resources>=0.17.3,<0.18.0",
     "invenio-i18n>=1.3.1",
+    "lxml>=4.1.1",
+    "PyYAML>=5.4.1",
 ]
 
 packages = find_packages()

--- a/tests/contrib/names/test_names_datastreams.py
+++ b/tests/contrib/names/test_names_datastreams.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Names data streams tests."""
+
+
+import pytest
+
+from invenio_vocabularies.contrib.names.datastreams import OrcidXMLTransformer
+
+
+@pytest.fixture(scope='module')
+def expected_from_xml():
+    return {
+        'given_name': 'Lars Holm',
+        'family_name': 'Nielsen',
+        'identifiers': [
+            {
+                'scheme': 'orcid',
+                'identifier': 'https://orcid.org/0000-0001-8135-3489'
+            }
+        ],
+        'affiliations': [{'name': 'CERN'}]
+    }
+
+
+@pytest.fixture(scope='module')
+def xml_entry():
+    # simplified version of an XML file of the ORCiD dump
+    return bytes(
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n'
+        '<record:record path="/0000-0001-8135-3489">\n'
+        '    <common:orcid-identifier>\n'
+        '        <common:uri>https://orcid.org/0000-0001-8135-3489</common:uri>\n'  # noqa
+        '        <common:path>0000-0001-8135-3489</common:path>\n'
+        '        <common:host>orcid.org</common:host>\n'
+        '    </common:orcid-identifier>\n'
+        '    <person:person path="/0000-0001-8135-3489/person">\n'
+        '        <person:name visibility="public" path="0000-0001-8135-3489">\n'  # noqa
+        '            <personal-details:given-names>Lars Holm</personal-details:given-names>'  # noqa
+        '            <personal-details:family-name>Nielsen</personal-details:family-name>\n'  # noqa
+        '        </person:name>\n'
+        '        <external-identifier:external-identifiers path="/0000-0001-8135-3489/external-identifiers"/>\n'  # noqa
+        '    </person:person>\n'
+        '    <activities:activities-summary path="/0000-0001-8135-3489/activities">\n'  # noqa
+        '       <activities:employments path="/0000-0001-8135-3489/employments">\n'  # noqa
+        '           <employments:affiliation-group>\n'
+        '               <employments:employment-summary>\n'
+        '                   <employment-summary:organization>\n'
+        '                       <organization:name>CERN</organization:name>\n'
+        '                   </employment-summary:organization>\n'
+        '               </employments:employment-summary>\n'
+        '           </employments:affiliation-group>\n'
+        '       </activities:employments>\n'
+        '    </activities:activities-summary>\n'
+        '</record:record>\n',
+        encoding="raw_unicode_escape"
+    )
+
+
+def test_orcid_xml_transformer(xml_entry, expected_from_xml):
+    transformer = OrcidXMLTransformer()
+    assert expected_from_xml == transformer.apply(xml_entry)

--- a/tests/datastreams/conftest.py
+++ b/tests/datastreams/conftest.py
@@ -14,7 +14,8 @@ fixtures are available.
 
 import pytest
 
-from invenio_vocabularies.datastreams.errors import TransformerError, WriterError
+from invenio_vocabularies.datastreams.errors import TransformerError, \
+    WriterError
 from invenio_vocabularies.datastreams.readers import BaseReader
 from invenio_vocabularies.datastreams.transformers import BaseTransformer
 from invenio_vocabularies.datastreams.writers import BaseWriter
@@ -61,13 +62,13 @@ class FailingTestWriter(BaseWriter):
 @pytest.fixture(scope='module')
 def app_config(app_config):
     """Mimic an instance's configuration."""
-    app_config["VOCABULARIES_DATASOURCE_READERS"] = {
+    app_config["VOCABULARIES_DATASTREAM_READERS"] = {
         "test": TestReader
     }
-    app_config["VOCABULARIES_DATASOURCE_TRANSFORMERS"] = {
+    app_config["VOCABULARIES_DATASTREAM_TRANSFORMERS"] = {
         "test": TestTransformer
     }
-    app_config["VOCABULARIES_DATASOURCE_WRITERS"] = {
+    app_config["VOCABULARIES_DATASTREAM_WRITERS"] = {
         "test": TestWriter,
         "fail": FailingTestWriter,
     }

--- a/tests/datastreams/test_readers.py
+++ b/tests/datastreams/test_readers.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Data Streams readers tests."""
+
+import tarfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+from invenio_vocabularies.datastreams.readers import TarReader, YamlReader
+
+
+@pytest.fixture(scope='module')
+def expected_from_yaml():
+    return [
+        {
+            "test": {
+                "inner": "value"
+            }
+        }, {
+            "test": {
+                "inner": "value"
+            }
+        }
+    ]
+
+
+@pytest.fixture(scope='function')
+def yaml_file(expected_from_yaml):
+    filename = Path('reader_test.yaml')
+    with open(filename, 'w') as file:
+        yaml.dump(expected_from_yaml, file)
+
+    yield filename
+
+    filename.unlink()  # delete created file
+
+
+def test_yaml_reader(yaml_file, expected_from_yaml):
+    reader = YamlReader(yaml_file)
+
+    for idx, entry in enumerate(reader.read()):
+        assert entry == expected_from_yaml[idx]
+
+
+@pytest.fixture(scope='module')
+def expected_from_tar():
+    return {
+        "test": {
+            "inner": "value"
+        }
+    }
+
+
+@pytest.fixture(scope='function')
+def tar_file(expected_from_tar):
+    """Creates a Tar file with three files (two yaml) inside.
+
+    Each iteration should return the content of one yaml file,
+    it should ignore the .other file.
+    """
+    files = ["file_one.yaml", "file_two.yaml", "file_three.other"]
+    filename = Path("reader_test.tar.gz")
+    with tarfile.open(filename, "w:gz") as tar:
+        for file_ in files:
+            inner_filename = Path(file_)
+            with open(inner_filename, 'w') as file:
+                yaml.dump(expected_from_tar, file)
+                tar.add(inner_filename)
+            inner_filename.unlink()
+
+    yield filename
+
+    filename.unlink()  # delete created file
+
+
+def test_tar_reader(tar_file, expected_from_tar):
+    reader = TarReader(tar_file, regex=".yaml$")
+
+    total = 0
+    for entry in reader.read():
+        assert yaml.safe_load(entry) == expected_from_tar
+        total += 1
+
+    assert total == 2  # ignored the `.other` file

--- a/tests/datastreams/test_writers.py
+++ b/tests/datastreams/test_writers.py
@@ -8,7 +8,11 @@
 
 """Data Streams writers tests."""
 
-from invenio_vocabularies.datastreams.writers import ServiceWriter
+from pathlib import Path
+
+import yaml
+
+from invenio_vocabularies.datastreams.writers import ServiceWriter, YamlWriter
 
 
 def test_service_writer(lang_type, lang_data, service, identity):
@@ -18,3 +22,20 @@ def test_service_writer(lang_type, lang_data, service, identity):
     record = record.to_dict()
 
     assert dict(record, **lang_data) == record
+
+
+def test_yaml_writer():
+    filepath = Path('writer_test.yaml')
+    test_output = [
+        {"key_one": [{"inner_one": 1}]},
+        {"key_two": [{"inner_two": "two"}]}
+    ]
+
+    writer = YamlWriter(filepath=filepath)
+    for output in test_output:
+        assert not writer.write(entry=output).errors
+
+    with open(filepath) as file:
+        assert yaml.safe_load(file) == test_output
+
+    filepath.unlink()

--- a/tests/datastreams/test_writers.py
+++ b/tests/datastreams/test_writers.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Data Streams writers tests."""
+
+from invenio_vocabularies.datastreams.writers import ServiceWriter
+
+
+def test_service_writer(lang_type, lang_data, service, identity):
+    writer = ServiceWriter(service, identity)
+    lang = writer.write(entry=lang_data)
+    record = service.read(("languages", lang.id), identity)
+    record = record.to_dict()
+
+    assert dict(record, **lang_data) == record

--- a/tests/datastreams/vocabularies.yaml
+++ b/tests/datastreams/vocabularies.yaml
@@ -9,7 +9,7 @@ testone:
   writers:
     - type: test
 testtwo:
-  pid-type: testid
+  pid-type: testit
   transformers:
     - type: test
   reader:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import pytest
 from invenio_access.permissions import system_identity
 
-from invenio_vocabularies.cli import _import_vocab
+from invenio_vocabularies.cli import _process_vocab, get_config_for_ds
 from invenio_vocabularies.contrib.names.api import Name
 from invenio_vocabularies.contrib.names.datastreams import OrcidXMLTransformer
 from invenio_vocabularies.contrib.names.services import NamesService, \
@@ -114,8 +114,11 @@ def names_tar_file(expected_name_xml):
     filename.unlink()  # delete created file
 
 
-def test_import(app, names_tar_file, names_service):
-    _import_vocab(vocabulary="names", origin=names_tar_file.absolute())
+def test_process(app, names_tar_file, names_service):
+    config = get_config_for_ds(
+        vocabulary="names", origin=names_tar_file.absolute()
+    )
+    _process_vocab(config)
     Name.index.refresh()
 
     orcid = "0000-0001-8135-3489"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""CLI Module tests."""
+
+import tarfile
+from pathlib import Path
+
+import pytest
+from invenio_access.permissions import system_identity
+
+from invenio_vocabularies.cli import _import_vocab
+from invenio_vocabularies.contrib.names.api import Name
+from invenio_vocabularies.contrib.names.datastreams import OrcidXMLTransformer
+from invenio_vocabularies.contrib.names.services import NamesService, \
+    NamesServiceConfig
+
+
+@pytest.fixture(scope='module')
+def names_service():
+    """Names service object."""
+    return NamesService(config=NamesServiceConfig)
+
+
+@pytest.fixture(scope="module")
+def extra_entry_points():
+    """Extra entry points to load the mock_module features."""
+    return {
+        'invenio_db.model': [
+            'names = invenio_vocabularies.contrib.names.models',
+        ],
+        'invenio_jsonschemas.schemas': [
+            'names = invenio_vocabularies.contrib.names.jsonschemas',
+        ],
+        'invenio_search.mappings': [
+            'names = invenio_vocabularies.contrib.names.mappings',
+        ]
+    }
+
+
+@pytest.fixture(scope="module")
+def base_app(base_app, names_service):
+    """Application factory fixture."""
+    registry = base_app.extensions['invenio-records-resources'].registry
+    registry.register(names_service, service_id='rdm-names')
+
+    yield base_app
+
+
+@pytest.fixture(scope='module')
+def app_config(app_config):
+    """Mimic an instance's configuration."""
+    app_config["VOCABULARIES_DATASTREAM_TRANSFORMERS"] = {
+        "orcid-xml": OrcidXMLTransformer
+    }
+
+    return app_config
+
+
+@pytest.fixture(scope='module')
+def expected_name_xml():
+    return (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n'
+        '<record:record path="/0000-0001-8135-3489">\n'
+        '    <common:orcid-identifier>\n'
+        '        <common:uri>https://orcid.org/0000-0001-8135-3489</common:uri>\n'  # noqa
+        '        <common:path>0000-0001-8135-3489</common:path>\n'
+        '        <common:host>orcid.org</common:host>\n'
+        '    </common:orcid-identifier>\n'
+        '    <person:person path="/0000-0001-8135-3489/person">\n'
+        '        <person:name visibility="public" path="0000-0001-8135-3489">\n'  # noqa
+        '            <personal-details:given-names>Lars Holm</personal-details:given-names>'  # noqa
+        '            <personal-details:family-name>Nielsen</personal-details:family-name>\n'  # noqa
+        '        </person:name>\n'
+        '        <external-identifier:external-identifiers path="/0000-0001-8135-3489/external-identifiers"/>\n'  # noqa
+        '    </person:person>\n'
+        '    <activities:activities-summary path="/0000-0001-8135-3489/activities">\n'  # noqa
+        '       <activities:employments path="/0000-0001-8135-3489/employments">\n'  # noqa
+        '           <employments:affiliation-group>\n'
+        '               <employments:employment-summary>\n'
+        '                   <employment-summary:organization>\n'
+        '                       <organization:name>CERN</organization:name>\n'
+        '                   </employment-summary:organization>\n'
+        '               </employments:employment-summary>\n'
+        '           </employments:affiliation-group>\n'
+        '       </activities:employments>\n'
+        '    </activities:activities-summary>\n'
+        '</record:record>\n'
+    )
+
+
+@pytest.fixture(scope='function')
+def names_tar_file(expected_name_xml):
+    """Creates a Tar file with three files (two yaml) inside.
+
+    Each iteration should return the content of one yaml file,
+    it should ignore the .other file.
+    """
+    filename = Path("cli_test.tar.gz")
+    with tarfile.open(filename, "w:gz") as tar:
+        inner_filename = Path("lnielsen_name.xml")
+        with open(inner_filename, 'w') as file:
+            file.write(expected_name_xml)
+        tar.add(inner_filename)
+        inner_filename.unlink()
+
+    yield filename
+
+    filename.unlink()  # delete created file
+
+
+def test_import(app, names_tar_file, names_service):
+    _import_vocab(vocabulary="names", origin=names_tar_file.absolute())
+    Name.index.refresh()
+
+    orcid = "0000-0001-8135-3489"
+    results = names_service.search(
+        system_identity,
+        q=f"identifiers.identifier:{orcid}"
+    )
+
+    assert results.total == 1
+    assert list(results.hits)[0]["identifiers"][0]["identifier"] == orcid


### PR DESCRIPTION
- closes https://github.com/inveniosoftware/invenio-vocabularies/issues/85
- closes https://github.com/inveniosoftware/invenio-vocabularies/issues/89

## Sample commands

### Import

```bash
invenio vocabularies import -v names -o "/.../ORCID_2020_10_summaries.tar.gz"
-n 1000
```

**Outputs**

```
ServiceWriter: [{'ValidationError': {'family_name': ['Field may not be null.']}}]
OrcidXMLTransformer: Record not found in ORCiD entry.
ServiceWriter: [{'ValidationError': {'family_name': ['Field may not be null.']}}]
...
Number of samples reached 1000
Vocabulary names loaded. Total items 1000.
960 items succeeded, 40 contained errors.
```

Left it running for around 100k, there were 3k errors (3-4%). All of them were one of the above (missing _record_ of part of the _name_)

### Convert

```bash
invenio vocabularies convert -v names -o "/.../ORCID_2020_10_summaries.tar.gz" -t "/.../test_orcid.yaml" -n 10
```

Sample of the produced file:
```yaml
- affiliations: []
  family_name: Vilela Santos
  given_name: Cristiano
  identifiers:
  - identifier: https://orcid.org/0000-0001-5014-4000
    scheme: orcid
- affiliations: []
  family_name: Olonilua
  given_name: Oluponmile
  identifiers:
  - identifier: https://orcid.org/0000-0001-5087-3000
    scheme: orcid
- affiliations:
  - name: PCSIR Labs. Complex, Ferozepur Road
  family_name: Sabri
  given_name: Muhammad Usman
  identifiers:
  - identifier: https://orcid.org/0000-0001-5042-7000
    scheme: orcid
- affiliations: []
  family_name: de Medeiros
  given_name: "Jo\xE3o Vitor"
  identifiers:
  - identifier: https://orcid.org/0000-0001-5022-4000
    scheme: orcid
- affiliations: []
  family_name: Hopcroft
  given_name: Russell
  identifiers:
  - identifier: https://orcid.org/0000-0001-5021-6000
    scheme: orcid
- affiliations: []
  family_name: "\u0426\u0430\u0440\u0430\u043A\u0430\u0435\u0432\u0430"
  given_name: "\u0415\u043A\u0430\u0442\u0435\u0440\u0438\u043D\u0430"
  identifiers:
  - identifier: https://orcid.org/0000-0001-5104-0000
    scheme: orcid
```