### PR TITLE
Tasks REST API

### DIFF
--- a/invenio_vocabularies/services/permissions.py
+++ b/invenio_vocabularies/services/permissions.py
@@ -21,6 +21,3 @@ class PermissionPolicy(RecordPermissionPolicy):
     can_update = [SystemProcess()]
     can_delete = [SystemProcess()]
     can_manage = [SystemProcess()]
-
-    # Type permissions
-    can_manage = [SystemProcess()]

--- a/invenio_vocabularies/services/schema.py
+++ b/invenio_vocabularies/services/schema.py
@@ -29,10 +29,33 @@ class BaseVocabularySchema(BaseRecordSchema):
 
 
 class VocabularySchema(BaseVocabularySchema):
-    """Service schema for vocabulary records.."""
+    """Service schema for vocabulary records."""
 
     props = fields.Dict(
         allow_none=False, keys=fields.Str(), values=fields.Str()
     )
     tags = fields.List(SanitizedUnicode())
     type = fields.Str(attribute='type.id', required=True)
+
+
+class DatastreamObject(Schema):
+    """Datastream object (reader, transformer, writer)."""
+
+    type = fields.Str(required=True)
+    args = fields.Dict(keys=fields.Str(), values=fields.Field)
+
+
+class TaskSchema(Schema):
+    """Service schema for vocabulary tasks."""
+
+    reader = fields.Nested(DatastreamObject, required=True)
+    transformers = fields.List(
+        fields.Nested(DatastreamObject),
+        validate=validate.Length(min=1),
+        required=False,
+    )
+    writers = fields.List(
+        fields.Nested(DatastreamObject),
+        validate=validate.Length(min=1),
+        required=True,
+    )

--- a/invenio_vocabularies/services/tasks.py
+++ b/invenio_vocabularies/services/tasks.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 CERN.
+#
+# Invenio-RDM-Records is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Celery tasks."""
+
+from celery import shared_task
+from flask import current_app
+
+from ..datastreams.factories import DataStreamFactory
+
+
+@shared_task(ignore_result=True)
+def process_datastream(config):
+    """Lift expired embargos."""
+    ds = DataStreamFactory.create(
+        reader_config=config["reader"],
+        transformers_config=config.get("transformers"),
+        writers_config=config["writers"],
+    )
+
+    for result in ds.process():
+        if result.errors:
+            for err in result.errors:
+                current_app.logger.error(err)

--- a/tests/datastreams/test_datastreams.py
+++ b/tests/datastreams/test_datastreams.py
@@ -19,7 +19,6 @@ from invenio_vocabularies.datastreams.factories import DataStreamFactory
 def vocabulary_config():
     """Parsed vocabulary configuration."""
     return {
-        "pid-type": "testid",
         "transformers": [
             {"type": "test"}
         ],

--- a/tests/resources/conftest.py
+++ b/tests/resources/conftest.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Pytest configuration.
+
+See https://pytest-invenio.readthedocs.io/ for documentation on which test
+fixtures are available.
+"""
+
+import pytest
+from flask_security import login_user
+from flask_security.utils import hash_password
+from invenio_access.permissions import ActionUsers
+from invenio_access.proxies import current_access
+from invenio_accounts.proxies import current_datastore
+from invenio_accounts.testutils import login_user_via_session
+
+
+@pytest.fixture()
+def user(app, db):
+    """Create example user."""
+    with db.session.begin_nested():
+        datastore = app.extensions["security"].datastore
+        _user = datastore.create_user(
+            email="info@inveniosoftware.org",
+            password=hash_password("password"),
+            active=True
+        )
+    db.session.commit()
+    return _user
+
+
+@pytest.fixture()
+def role(app, db):
+    """Create some roles."""
+    with db.session.begin_nested():
+        datastore = app.extensions["security"].datastore
+        role = datastore.create_role(name="admin", description="admin role")
+
+    db.session.commit()
+    return role
+
+
+@pytest.fixture()
+def client_with_credentials(db, client, user, role):
+    """Log in a user to the client."""
+    current_datastore.add_role_to_user(user, role)
+    action = current_access.actions["superuser-access"]
+    db.session.add(ActionUsers.allow(action, user_id=user.id))
+
+    login_user(user, remember=True)
+    login_user_via_session(client, email=user.email)
+
+    return client

--- a/tests/resources/test_tasks_resources.py
+++ b/tests/resources/test_tasks_resources.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Tasks REST API tests."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from invenio_vocabularies.datastreams.datastreams import StreamResult
+from invenio_vocabularies.datastreams.readers import BaseReader
+from invenio_vocabularies.datastreams.transformers import BaseTransformer
+from invenio_vocabularies.datastreams.writers import BaseWriter
+
+
+@pytest.fixture(scope='module')
+def app_config(app_config):
+    """Mimic an instance's configuration."""
+    app_config["VOCABULARIES_DATASTREAM_READERS"] = {
+        "test": BaseReader
+    }
+    app_config["VOCABULARIES_DATASTREAM_TRANSFORMERS"] = {
+        "test": BaseTransformer
+    }
+    app_config["VOCABULARIES_DATASTREAM_WRITERS"] = {
+        "test": BaseWriter
+    }
+
+    return app_config
+
+
+def test_read(*args, **kwargs):
+    yield {}
+
+
+def test_apply(*args, **kwargs):
+    return {}
+
+
+def test_write(*args, **kwargs):
+    return StreamResult(entry={}, errors=[])
+
+
+@patch(
+    'invenio_vocabularies.datastreams.readers.BaseReader.read',
+    side_effect=test_read
+)
+@patch(
+    'invenio_vocabularies.datastreams.transformers.BaseTransformer.apply',
+    side_effect=test_apply
+)
+@patch(
+    'invenio_vocabularies.datastreams.writers.BaseWriter.write',
+    side_effect=test_write
+)
+def test_task_creation(
+    p_read, p_apply, p_write, app, client_with_credentials, h
+):
+    client = client_with_credentials
+    task_config = {
+        "reader": {
+            "type": "test",
+            "args": {
+                "origin": "somewhere"
+            }
+        },
+        "transformers": [{"type": "test"}],
+        "writers": [{"type": "test"}]
+    }
+
+    resp = client.post(
+        "/vocabularies/tasks", headers=h, data=json.dumps(task_config)
+    )
+    assert resp.status_code == 202
+    p_read.assert_called()
+    p_apply.assert_called()
+    p_write.assert_called()

--- a/tests/services/test_schema.py
+++ b/tests/services/test_schema.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Service schemas tests."""
+
+import pytest
+from marshmallow import ValidationError
+
+from invenio_vocabularies.services.schema import TaskSchema
+
+
+def test_valid_minimal():
+    valid_minimal = {
+        "reader": {
+            "type": "test"
+        },
+        "writers": [{"type": "test"}]
+    }
+    assert valid_minimal == TaskSchema().load(valid_minimal)
+
+
+def test_valid_full():
+    valid_full = {
+        "reader": {
+            "type": "test",
+            "args": {
+                "one": 1,
+                "two": "two"
+            }
+        },
+        "transformers": [{
+            "type": "test",
+            "args": {
+                "one": 1,
+                "two": "two"
+            }
+        }, {
+            "type": "testtoo",
+            "args": {
+                "one": "1",
+                "two": 2
+            }
+        }],
+        "writers": [{
+            "type": "test",
+            "args": {
+                "one": 1,
+                "two": "two"
+            }
+        }, {
+            "type": "testtoo",
+            "args": {
+                "one": "1",
+                "two": 2
+            }
+        }],
+    }
+    assert valid_full == TaskSchema().load(valid_full)
+
+
+@pytest.mark.parametrize("invalid", [
+    {},
+    {
+        "reader": [{"type": "test"}, {"type": "testtoo"}],
+        "writers": [{"type": "test"}]
+    },
+    {
+        "reader": {"type": "testtoo"},
+        "writers": {"type": "test"}
+    },
+    {
+        "reader": {"type": "testtoo"},
+        "transformers": {"type": "test"},
+        "writers": [{"type": "test"}]
+    },
+    {
+        "reader": {"type": "testtoo"},
+    },
+    {
+        "writers": [{"type": "test"}]
+    },
+])
+def test_invalid_empty(invalid):
+    with pytest.raises(ValidationError):
+        data = TaskSchema().load(invalid)


### PR DESCRIPTION
- closes https://github.com/inveniosoftware/invenio-vocabularies/issues/125


**I am not convinced of the implementation**, it looks a bit ad-hoc (no uow, adding `task_schema` to the config, and so on). IMO, it should be a separate resource (like PIDs in `invenio-rdm-records`) but this serves as PoC.

@slint might be missing a test at service level... but is indirectly tested by the resource since the tasks are run eagerly in tests.