### PR TITLE
contrib: add orcid http reader for names

### DIFF
--- a/invenio_vocabularies/contrib/names/datastreams.py
+++ b/invenio_vocabularies/contrib/names/datastreams.py
@@ -42,12 +42,21 @@ class OrcidXMLTransformer(XMLTransformer):
         }
 
         try:
-            affiliation = dict_lookup(
-                record,
-                "activities-summary.employments.affiliation-group"
-                ".employment-summary.organization.name",
+            employments =  dict_lookup(
+                record, "activities-summary.employments.affiliation-group"
             )
-            entry["affiliations"].append({"name": affiliation})
+            if isinstance(employments, dict):
+                employments = [employments]
+            history = set()
+            for employment in employments:
+                terminated = employment["employment-summary"].get("end-date")
+                affiliation = dict_lookup(
+                    employment,
+                    "employment-summary.organization.name",
+                )
+                if affiliation not in history and not terminated:
+                    history.add(affiliation)
+                    entry["affiliations"].append({"name": affiliation})
         except Exception:
             pass
 

--- a/invenio_vocabularies/contrib/names/datastreams.py
+++ b/invenio_vocabularies/contrib/names/datastreams.py
@@ -8,11 +8,26 @@
 
 """Names datastreams, transformers, writers and readers."""
 
+import requests
 from invenio_access.permissions import system_identity
 from invenio_records.dictutils import dict_lookup
 
 from ...datastreams.errors import TransformerError
+from ...datastreams.readers import SimpleHTTPReader
 from ...datastreams.transformers import XMLTransformer
+
+
+class OrcidHTTPReader(SimpleHTTPReader):
+    """ORCiD HTTP Reader."""
+
+    def __init__(self, *args, test_mode=True, **kwargs):
+        """Constructor."""
+        if test_mode:
+            origin = "https://sandbox.orcid.org/{id}"
+        else:
+            origin = "https://orcid.org/{id}"
+
+        super().__init__(origin, *args, **kwargs)
 
 
 class OrcidXMLTransformer(XMLTransformer):
@@ -42,7 +57,7 @@ class OrcidXMLTransformer(XMLTransformer):
         }
 
         try:
-            employments =  dict_lookup(
+            employments = dict_lookup(
                 record, "activities-summary.employments.affiliation-group"
             )
             if isinstance(employments, dict):
@@ -61,6 +76,11 @@ class OrcidXMLTransformer(XMLTransformer):
             pass
 
         return entry
+
+
+VOCABULARIES_DATASTREAM_READERS = {
+    "orcid-http": OrcidHTTPReader,
+}
 
 
 VOCABULARIES_DATASTREAM_TRANSFORMERS = {

--- a/invenio_vocabularies/datastreams/readers.py
+++ b/invenio_vocabularies/datastreams/readers.py
@@ -11,6 +11,7 @@
 import re
 import tarfile
 
+import requests
 import yaml
 
 
@@ -54,3 +55,29 @@ class TarReader(BaseReader):
                 if member.isfile() and match:
                     content = archive.extractfile(member).read()
                     yield content
+
+
+class SimpleHTTPReader(BaseReader):
+    """Simple HTTP Reader."""
+
+    def __init__(
+        self, origin, id=None, ids=None, content_type=None, *args, **kwargs
+    ):
+        """Constructor."""
+        assert id or ids
+        self._ids = ids if ids else [id]
+        self.content_type = content_type
+        super().__init__(origin, *args, **kwargs)
+
+    def read(self):
+        """Reads a yaml file and returns a dictionary per element."""
+        headers = {"Accept": self.content_type}
+
+        for id_ in self._ids:
+            url = self._origin.format(id=id_)
+            resp = requests.get(url, headers=headers)
+            if resp.status_code != 200:
+                # todo add logging/fail
+                pass
+
+            yield resp.content


### PR DESCRIPTION
Closed https://github.com/inveniosoftware/invenio-vocabularies/pull/123 by mistake

- closes https://github.com/inveniosoftware/invenio-vocabularies/issues/126

Example of programmatic usage (which is the flow of datastream aprox):

```
>>> from invenio_vocabularies.contrib.names.datastreams import OrcidHTTPReader, OrcidXMLTransformer
>>> reader = OrcidHTTPReader(orcid_id="0000-0001-6759-6273", test_mode=False)
>>> OrcidXMLTransformer().apply(reader.read())
{'given_name': 'Pablo', 'family_name': 'Panero', 'identifiers': [{'scheme': 'orcid', 'identifier': 'https://orcid.org/0000-0001-6759-6273'}], 'affiliations': []}
```