### PR TITLE
cli: implement update command and adapt service writer

### DIFF
--- a/invenio_vocabularies/cli.py
+++ b/invenio_vocabularies/cli.py
@@ -44,7 +44,6 @@ def get_service_for_vocabulary(vocabulary):
 @click.group()
 def vocabularies():
     """Vocabularies command."""
-    pass
 
 
 def _process_vocab(config, num_samples=None):
@@ -101,7 +100,28 @@ def import_vocab(vocabulary, filepath=None, origin=None, num_samples=None):
     config = get_config_for_ds(vocabulary, filepath, origin)
     success, errored = _process_vocab(config, num_samples)
 
-    _output_process(vocabulary, "loaded", success, errored)
+    _output_process(vocabulary, "imported", success, errored)
+
+
+@vocabularies.command()
+@click.option("-v", "--vocabulary", type=click.STRING, required=True)
+@click.option("-f", "--filepath", type=click.STRING)
+@click.option("-o", "--origin", type=click.STRING)
+@with_appcontext
+def update(vocabulary, filepath=None, origin=None):
+    """Import a vocabulary."""
+    if not filepath and not origin:
+        click.secho("One of --filepath or --origin must be present", fg="red")
+        exit(1)
+
+    config = get_config_for_ds(vocabulary, filepath, origin)
+
+    for w_conf in config["writers"]:
+        w_conf["args"]["update"] = True
+
+    success, errored = _process_vocab(config)
+
+    _output_process(vocabulary, "updated", success, errored)
 
 
 @vocabularies.command()
@@ -156,7 +176,6 @@ def delete(vocabulary, identifier, all):
         )
         exit(1)
 
-    breakpoint()
     service = get_service_for_vocabulary(vocabulary)
     if identifier:
         try:

--- a/invenio_vocabularies/contrib/names/datastreams.py
+++ b/invenio_vocabularies/contrib/names/datastreams.py
@@ -10,12 +10,15 @@
 
 import requests
 from invenio_access.permissions import system_identity
+from invenio_pidstore.errors import PIDDoesNotExistError
 from invenio_records.dictutils import dict_lookup
+from marshmallow import ValidationError
 
 from ...datastreams import StreamEntry
-from ...datastreams.errors import TransformerError
+from ...datastreams.errors import TransformerError, WriterError
 from ...datastreams.readers import SimpleHTTPReader
 from ...datastreams.transformers import XMLTransformer
+from ...datastreams.writers import ServiceWriter
 
 
 class OrcidHTTPReader(SimpleHTTPReader):
@@ -76,7 +79,51 @@ class OrcidXMLTransformer(XMLTransformer):
         except Exception:
             pass
 
-        return StreamEntry(entry)
+        stream_entry.entry = entry
+        return stream_entry
+
+
+class NamesServiceWriter(ServiceWriter):
+    """Names service writer."""
+
+    def __init__(self, *args, scheme_id="orcid", **kwargs):
+        """Constructor."""
+        self._scheme_id = scheme_id
+        super().__init__(*args, **kwargs)
+
+    def _entry_id(self, entry):
+        """Get the id from an entry."""
+        for identifier in entry.get("identifiers"):
+            if identifier.get("scheme") == self._scheme_id:
+                return identifier["identifier"]
+
+    def _resolve(self, id_):
+        """Resolve an entry given an id."""
+        return self._service.resolve(
+            self._identity, id_=id_, id_type=self._scheme_id
+        )
+
+    def write(self, stream_entry, *args, **kwargs):
+        """Writes the input entry using a given service."""
+        entry = stream_entry.entry
+        try:
+            vocab_id = self._entry_id(entry)
+            # it is resolved before creation to avoid duplicates since
+            # the pid is recidv2 not e.g. the orcid
+            current = self._resolve(vocab_id)
+            if not self._update:
+                raise WriterError(
+                    [f"Vocabulary entry already exists: {entry}"]
+                )
+            updated = dict(current.to_dict(), **entry)
+            return StreamEntry(
+                self._service.update(self._identity, current.id, updated)
+            )
+        except PIDDoesNotExistError:
+            return StreamEntry(self._service.create(self._identity, entry))
+
+        except ValidationError as err:
+            raise WriterError([{"ValidationError": err.messages}])
 
 
 VOCABULARIES_DATASTREAM_READERS = {
@@ -89,6 +136,13 @@ VOCABULARIES_DATASTREAM_TRANSFORMERS = {
 }
 """ORCiD Data Streams transformers."""
 
+
+VOCABULARIES_DATASTREAM_WRITERS = {
+    "names-service": NamesServiceWriter,
+}
+"""ORCiD Data Streams transformers."""
+
+
 DATASTREAM_CONFIG = {
     "reader": {
         "type": "tar",
@@ -100,7 +154,7 @@ DATASTREAM_CONFIG = {
         {"type": "orcid-xml"}
     ],
     "writers": [{
-        "type": "service",
+        "type": "names-service",
         "args": {
             "service_or_name": "rdm-names",
             "identity": system_identity,

--- a/invenio_vocabularies/datastreams/datastreams.py
+++ b/invenio_vocabularies/datastreams/datastreams.py
@@ -59,11 +59,11 @@ class BaseDataStream:
             try:
                 stream_entry = transformer.apply(stream_entry)
             except TransformerError as err:
-                return StreamEntry(
-                    stream_entry.entry,
-                    # FIXME: __ is ugly, add name cls attr?
-                    [f"{transformer.__class__.__name__}: {str(err)}"]
+                # FIXME: __ is ugly, add name cls attr?
+                stream_entry.errors.append(
+                    f"{transformer.__class__.__name__}: {str(err)}"
                 )
+                return stream_entry  # break loop
 
         return stream_entry
 

--- a/invenio_vocabularies/datastreams/readers.py
+++ b/invenio_vocabularies/datastreams/readers.py
@@ -59,7 +59,7 @@ class TarReader(BaseReader):
                 match = not self._regex or self._regex.search(member.name)
                 if member.isfile() and match:
                     content = archive.extractfile(member).read()
-                    yield StreamEntry(entry=content)
+                    yield StreamEntry(content)
 
 
 class SimpleHTTPReader(BaseReader):

--- a/invenio_vocabularies/datastreams/transformers.py
+++ b/invenio_vocabularies/datastreams/transformers.py
@@ -74,4 +74,5 @@ class XMLTransformer(BaseTransformer):
         if not record:
             raise TransformerError(f"Record not found in XML entry.")
 
-        return StreamEntry(record)
+        stream_entry.entry = record
+        return stream_entry

--- a/invenio_vocabularies/datastreams/writers.py
+++ b/invenio_vocabularies/datastreams/writers.py
@@ -12,9 +12,11 @@ from pathlib import Path
 
 import yaml
 from invenio_access.permissions import system_identity
+from invenio_pidstore.errors import PIDAlreadyExists
 from invenio_records_resources.proxies import current_service_registry
 from marshmallow import ValidationError
 
+from .datastreams import StreamEntry
 from .errors import WriterError
 
 
@@ -38,29 +40,54 @@ class BaseWriter:
 class ServiceWriter(BaseWriter):
     """Writes the entries to an RDM instance using a Service object."""
 
-    def __init__(self, service_or_name, identity, *args, **kwargs):
+    def __init__(
+        self, service_or_name, identity, *args, update=False, **kwargs
+    ):
         """Constructor.
 
         :param service_or_name: a service instance or a key of the
                                 service registry.
         :param identity: access identity.
+        :param update: if True it will update records if they exist.
         """
         if isinstance(service_or_name, str):
             service_or_name = current_service_registry.get(service_or_name)
 
         self._service = service_or_name
         self._identity = system_identity
+        self._update = update
 
         super().__init__(*args, **kwargs)
 
+    def _entry_id(self, entry):
+        """Get the id from an entry."""
+        return (entry["type"], entry["id"])
+
+    def _resolve(self, id_):
+        return self._service.read(self._identity, id_)
+
     def write(self, stream_entry, *args, **kwargs):
         """Writes the input entry using a given service."""
+        entry = stream_entry.entry
         try:
-            result = self._service.create(self._identity, stream_entry.entry)
+            try:
+                return StreamEntry(
+                    self._service.create(self._identity, entry)
+                )
+            except PIDAlreadyExists:
+                if not self._update:
+                    raise WriterError(
+                        [f"Vocabulary entry already exists: {entry}"]
+                    )
+                vocab_id = self._entry_id(entry)
+                current = self._resolve(vocab_id)
+                updated = dict(current.to_dict(), **entry)
+                return StreamEntry(
+                    self._service.update(self._identity, vocab_id, updated)
+                )
+
         except ValidationError as err:
             raise WriterError([{"ValidationError": err.messages}])
-
-        return result
 
 
 class YamlWriter(BaseWriter):

--- a/tests/contrib/names/test_names_datastreams.py
+++ b/tests/contrib/names/test_names_datastreams.py
@@ -8,13 +8,66 @@
 
 """Names data streams tests."""
 
+from copy import deepcopy
 from unittest.mock import patch
 
 import pytest
+from invenio_access.permissions import system_identity
 
-from invenio_vocabularies.contrib.names.datastreams import OrcidHTTPReader, \
-    OrcidXMLTransformer
+from invenio_vocabularies.contrib.names.api import Name
+from invenio_vocabularies.contrib.names.datastreams import \
+    NamesServiceWriter, OrcidHTTPReader, OrcidXMLTransformer
+from invenio_vocabularies.contrib.names.services import NamesService, \
+    NamesServiceConfig
 from invenio_vocabularies.datastreams import StreamEntry
+from invenio_vocabularies.datastreams.errors import WriterError
+
+
+@pytest.fixture(scope='module')
+def names_service():
+    """Names service object."""
+    return NamesService(config=NamesServiceConfig)
+
+
+@pytest.fixture(scope="module")
+def extra_entry_points():
+    """Extra entry points to load the mock_module features."""
+    return {
+        'invenio_db.model': [
+            'names = invenio_vocabularies.contrib.names.models',
+        ],
+        'invenio_jsonschemas.schemas': [
+            'names = invenio_vocabularies.contrib.names.jsonschemas',
+        ],
+        'invenio_search.mappings': [
+            'names = invenio_vocabularies.contrib.names.mappings',
+        ]
+    }
+
+
+@pytest.fixture(scope="module")
+def base_app(base_app, names_service):
+    """Application factory fixture."""
+    registry = base_app.extensions['invenio-records-resources'].registry
+    registry.register(names_service, service_id='rdm-names')
+
+    yield base_app
+
+
+@pytest.fixture(scope="function")
+def name_full_data():
+    """Full name data."""
+    return {
+        'given_name': 'Lars Holm',
+        'family_name': 'Nielsen',
+        'identifiers': [
+            {
+                'scheme': 'orcid',
+                'identifier': '0000-0001-8135-3489'  # normalized after create
+            }
+        ],
+        'affiliations': [{'name': 'CERN'}]
+    }
 
 
 @pytest.fixture(scope='module')
@@ -63,7 +116,7 @@ XML_ENTRY_DATA = bytes(
     )
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def bytes_xml_entry():
     # simplified version of an XML file of the ORCiD dump
     return StreamEntry(XML_ENTRY_DATA)
@@ -89,3 +142,59 @@ def test_orcid_http_reader(_, bytes_xml_entry):
     assert len(results) == 1
     assert bytes_xml_entry.entry == results[0].entry
     assert not results[0].errors
+
+
+def test_names_service_writer_create(app, es_clear, name_full_data):
+    writer = NamesServiceWriter("rdm-names", system_identity)
+    record = writer.write(StreamEntry(name_full_data))
+    record = record.entry.to_dict()
+
+    assert dict(record, **name_full_data) == record
+
+
+def test_names_service_writer_duplicate(app, es_clear, name_full_data):
+    writer = NamesServiceWriter("rdm-names", system_identity)
+    _ = writer.write(stream_entry=StreamEntry(name_full_data))
+    Name.index.refresh()  # refresh index to make changes live
+    with pytest.raises(WriterError) as err:
+        writer.write(stream_entry=StreamEntry(name_full_data))
+
+    expected_error = [f"Vocabulary entry already exists: {name_full_data}"]
+    assert expected_error in err.value.args
+
+
+def test_names_service_writer_update_existing(
+    app, es_clear, name_full_data, names_service
+):
+    # create vocabulary
+    writer = NamesServiceWriter("rdm-names", system_identity, update=True)
+    name = writer.write(stream_entry=StreamEntry(name_full_data))
+    Name.index.refresh()  # refresh index to make changes live
+    # update vocabulary
+    updated_name = deepcopy(name_full_data)
+    updated_name["given_name"] = "Pablo"
+    updated_name["family_name"] = "Panero"
+    # check changes vocabulary
+    _ = writer.write(stream_entry=StreamEntry(updated_name))
+    record = names_service.read(system_identity, name.entry.id)
+    record = record.to_dict()
+
+    # needed while the writer resolves from ES
+    assert _.entry.id == name.entry.id
+    assert dict(record, **updated_name) == record
+
+
+def test_names_service_writer_update_non_existing(
+    app, es_clear, name_full_data, names_service
+):
+    # vocabulary item not created, call update directly
+    updated_name = deepcopy(name_full_data)
+    updated_name["given_name"] = "Pablo"
+    updated_name["family_name"] = "Panero"
+    # check changes vocabulary
+    writer = NamesServiceWriter("rdm-names", system_identity, update=True)
+    name = writer.write(stream_entry=StreamEntry(updated_name))
+    record = names_service.read(system_identity, name.entry.id)
+    record = record.to_dict()
+
+    assert dict(record, **updated_name) == record

--- a/tests/datastreams/conftest.py
+++ b/tests/datastreams/conftest.py
@@ -39,7 +39,8 @@ class TestTransformer(BaseTransformer):
         if stream_entry.entry < 0:
             raise TransformerError("Value cannot be negative")
 
-        return StreamEntry(stream_entry.entry + 1)
+        stream_entry.entry += 1
+        return stream_entry
 
 
 class TestWriter(BaseWriter):
@@ -54,7 +55,7 @@ class FailingTestWriter(BaseWriter):
         super().__init__()
         self.fail_on = fail_on
 
-    def write(self, stream_entry):
+    def write(self, stream_entry, *args, **kwargs):
         """Return the entry."""
         if stream_entry.entry == self.fail_on:
             raise WriterError(f"{self.fail_on} value found.")

--- a/tests/datastreams/test_writers.py
+++ b/tests/datastreams/test_writers.py
@@ -8,21 +8,68 @@
 
 """Data Streams writers tests."""
 
+from copy import deepcopy
 from pathlib import Path
 
+import pytest
 import yaml
 
 from invenio_vocabularies.datastreams import StreamEntry
+from invenio_vocabularies.datastreams.errors import WriterError
 from invenio_vocabularies.datastreams.writers import ServiceWriter, YamlWriter
 
 
-def test_service_writer(lang_type, lang_data, service, identity):
+def test_service_writer_non_existing(lang_type, lang_data, service, identity):
     writer = ServiceWriter(service, identity)
     lang = writer.write(stream_entry=StreamEntry(lang_data))
-    record = service.read(identity, ("languages", lang.id))
+    record = service.read(identity, ("languages", lang.entry.id))
     record = record.to_dict()
 
     assert dict(record, **lang_data) == record
+
+
+def test_service_writer_duplicate(lang_type, lang_data, service, identity):
+    writer = ServiceWriter(service, identity)
+    _ = writer.write(stream_entry=StreamEntry(lang_data))
+    with pytest.raises(WriterError) as err:
+        writer.write(stream_entry=StreamEntry(lang_data))
+
+    expected_error = [f"Vocabulary entry already exists: {lang_data}"]
+    assert expected_error in err.value.args
+
+
+def test_service_writer_update_existing(
+    lang_type, lang_data, service, identity
+):
+    # create vocabulary
+    writer = ServiceWriter(service, identity, update=True)
+    lang = writer.write(stream_entry=StreamEntry(lang_data))
+    # update vocabulary
+    updated_lang = deepcopy(lang_data)
+    updated_lang["description"]["en"] = "Updated english description"
+    updated_lang["tags"].append("updated")
+    # check changes vocabulary
+    _ = writer.write(stream_entry=StreamEntry(updated_lang))
+    record = service.read(identity, ("languages", lang.entry.id))
+    record = record.to_dict()
+
+    assert dict(record, **updated_lang) == record
+
+
+def test_service_writer_update_non_existing(
+    lang_type, lang_data, service, identity
+):
+    # vocabulary item not created, call update directly
+    updated_lang = deepcopy(lang_data)
+    updated_lang["description"]["en"] = "Updated english description"
+    updated_lang["tags"].append("updated")
+    # check changes vocabulary
+    writer = ServiceWriter(service, identity, update=True)
+    lang = writer.write(stream_entry=StreamEntry(updated_lang))
+    record = service.read(identity, ("languages", lang.entry.id))
+    record = record.to_dict()
+
+    assert dict(record, **updated_lang) == record
 
 
 def test_yaml_writer():
@@ -34,7 +81,7 @@ def test_yaml_writer():
 
     writer = YamlWriter(filepath=filepath)
     for output in test_output:
-        assert not writer.write(stream_entry=StreamEntry(output)).errors
+        writer.write(stream_entry=StreamEntry(output))
 
     with open(filepath) as file:
         assert yaml.safe_load(file) == test_output


### PR DESCRIPTION
closes #86 

Implements changes on the `ServiceWrite` to allow updating a record if it exists, by doing this the rest of the pipeline (readers, transformers) stay the same.