### PR TITLE
datastreams: implement default apply for xml transformer

### DIFF
--- a/invenio_vocabularies/datastreams/transformers.py
+++ b/invenio_vocabularies/datastreams/transformers.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2021 CERN.
+# Copyright (C) 2021-2022 CERN.
 #
 # Invenio-Vocabularies is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -11,6 +11,9 @@
 from collections import defaultdict
 
 from lxml import etree
+
+from .datastreams import StreamEntry
+from .errors import TransformerError
 
 
 class BaseTransformer:
@@ -59,3 +62,16 @@ class XMLTransformer(BaseTransformer):
             else:
                 d[tree.tag] = text
         return d
+
+    def apply(self, stream_entry, **kwargs):
+        """Applies the transformation to the stream entry.
+
+        Requires the root element to be named "record".
+        """
+        xml_tree = self._xml_to_etree(stream_entry.entry)
+        record = self._etree_to_dict(xml_tree)["html"]["body"].get("record")
+
+        if not record:
+            raise TransformerError(f"Record not found in XML entry.")
+
+        return StreamEntry(record)

--- a/tests/datastreams/test_transformers.py
+++ b/tests/datastreams/test_transformers.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Data Streams transformers tests."""
+
+import pytest
+
+from invenio_vocabularies.datastreams import StreamEntry
+from invenio_vocabularies.datastreams.errors import TransformerError
+from invenio_vocabularies.datastreams.transformers import XMLTransformer
+
+
+@pytest.fixture(scope='module')
+def expected_from_xml():
+    return {
+        'field_one': 'value',
+        'multi_field': {
+            'some': 'value',
+            'another': 'value too'
+        }
+    }
+
+
+def test_xml_transformer(expected_from_xml):
+    bytes_xml_entry = StreamEntry(bytes(
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n'
+        '<record:record>\n'
+        '    <field_one:field_one>value</field_one:field_one>\n'
+        '    <multi_field:multi_field>\n'
+        '        <some:some>value</some:some>\n'
+        '        <another:another>value too</another:another>\n'
+        '    </multi_field:multi_field>\n'
+        '</record:record>\n',
+        encoding="raw_unicode_escape"
+    ))
+
+    transformer = XMLTransformer()
+    assert expected_from_xml == transformer.apply(bytes_xml_entry).entry
+
+
+def test_bad_xml_transformer():
+    bytes_xml_entry = StreamEntry(bytes(
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n'
+        '<field_one:field_one>value</field_one:field_one>\n'
+        '<multi_field:multi_field>\n'
+        '    <some:some>value</some:some>\n'
+        '    <another:another>value too</another:another>\n'
+        '</multi_field:multi_field>\n',
+        encoding="raw_unicode_escape"
+    ))
+
+    transformer = XMLTransformer()
+    with pytest.raises(TransformerError):
+        transformer.apply(bytes_xml_entry)


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-vocabularies/issues/131

The `XMLTransformer` was more of a mixin than an actual base class since it did not implement correctly the API. Now it has a default apply, where all records would be returned fully as long as the base element is called `record`.