### PR TITLE
datastreams: funders readers and transformers

### DIFF
--- a/invenio_vocabularies/cli.py
+++ b/invenio_vocabularies/cli.py
@@ -18,6 +18,7 @@ from invenio_access.permissions import system_identity
 from invenio_pidstore.errors import PIDDeletedError, PIDDoesNotExistError
 from invenio_records_resources.proxies import current_service_registry
 
+from .contrib.funders.datastreams import DATASTREAM_CONFIG as funders_ds_config
 from .contrib.names.datastreams import DATASTREAM_CONFIG as names_ds_config
 from .datastreams import DataStreamFactory
 
@@ -30,7 +31,17 @@ def get_config_for_ds(vocabulary, filepath=None, origin=None):
             with open(filepath) as f:
                 config = yaml.safe_load(f).get(vocabulary)
         if origin:
-            config["reader"]["args"]["origin"] = origin
+            config["readers"][0]["args"]["origin"] = origin
+
+        return config
+
+    if vocabulary == "funders":
+        config = deepcopy(funders_ds_config)
+        if filepath:
+            with open(filepath) as f:
+                config = yaml.safe_load(f).get(vocabulary)
+        if origin:
+            config["readers"][0]["args"]["origin"] = origin
 
         return config
 
@@ -49,7 +60,7 @@ def vocabularies():
 def _process_vocab(config, num_samples=None):
     """Import a vocabulary."""
     ds = DataStreamFactory.create(
-        reader_config=config["reader"],
+        readers_config=config["readers"],
         transformers_config=config.get("transformers"),
         writers_config=config["writers"],
     )

--- a/invenio_vocabularies/config.py
+++ b/invenio_vocabularies/config.py
@@ -12,7 +12,8 @@
 import idutils
 from flask_babelex import lazy_gettext as _
 
-from .datastreams.readers import TarReader, YamlReader
+from .datastreams.readers import CSVReader, JsonReader, TarReader, \
+    YamlReader, ZipReader
 from .datastreams.transformers import XMLTransformer
 from .datastreams.writers import ServiceWriter, YamlWriter
 from .resources.resource import VocabulariesResourceConfig
@@ -51,8 +52,16 @@ VOCABULARIES_AFFILIATION_SCHEMES = {
 
 VOCABULARIES_FUNDER_SCHEMES = {
     **VOCABULARIES_IDENTIFIER_SCHEMES,
+    "doi": {
+        "label": _("DOI"),
+        "validator": idutils.is_doi
+    },
 }
 """Funders allowed identifier schemes."""
+
+VOCABULARIES_FUNDER_DOI_PREFIX = "10.13039"
+"""DOI prefix for the identifier formed with the FundRef id."""
+
 
 VOCABULARIES_NAMES_SCHEMES = {
     "orcid": {
@@ -74,8 +83,11 @@ VOCABULARIES_NAMES_SCHEMES = {
 """Names allowed identifier schemes."""
 
 VOCABULARIES_DATASTREAM_READERS = {
+    "csv": CSVReader,
+    "json": JsonReader,
     "tar": TarReader,
     "yaml": YamlReader,
+    "zip": ZipReader,
 }
 """Data Streams readers."""
 

--- a/invenio_vocabularies/contrib/funders/config.py
+++ b/invenio_vocabularies/contrib/funders/config.py
@@ -22,6 +22,10 @@ funder_schemes = LocalProxy(
     lambda: current_app.config["VOCABULARIES_FUNDER_SCHEMES"]
 )
 
+funder_fundref_doi_prefix = LocalProxy(
+    lambda: current_app.config["VOCABULARIES_FUNDER_DOI_PREFIX"]
+)
+
 
 class FundersSearchOptions(SearchOptions):
     """Search options."""

--- a/invenio_vocabularies/contrib/funders/datastreams.py
+++ b/invenio_vocabularies/contrib/funders/datastreams.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Funders datastreams, transformers, writers and readers."""
+
+from flask_babelex import lazy_gettext as _
+from idutils import normalize_ror
+from invenio_access.permissions import system_identity
+
+from ...datastreams.errors import TransformerError
+from ...datastreams.transformers import BaseTransformer
+from ...datastreams.writers import ServiceWriter
+from .config import funder_fundref_doi_prefix, funder_schemes
+
+
+class FundersServiceWriter(ServiceWriter):
+    """Funders service writer."""
+
+    def _entry_id(self, entry):
+        """Get the id from an entry."""
+        return entry["pid"]
+
+
+class RORTransformer(BaseTransformer):
+    """Transforms a JSON ROR record into a funders record."""
+
+    def apply(self, stream_entry, **kwargs):
+        """Applies the transformation to the stream entry."""
+        record = stream_entry.entry
+        funder = {}
+
+        funder["pid"] = normalize_ror(record.get("id"))
+        if not funder["pid"]:
+            raise TransformerError(
+                _(f"Id not found in ROR entry."))
+
+        funder["name"] = record.get("name")
+        if not funder["name"]:
+            raise TransformerError(_(f"Name not found in ROR entry."))
+
+        country_code = record.get("country", {}).get("country_code")
+        if country_code:
+            funder["country"] = country_code
+
+        funder["title"] = {}
+        for label in record.get("labels", []):
+            funder["title"][label["iso639"]] = label["label"]
+
+        funder["identifiers"] = []
+        valid_schemes = set(funder_schemes.keys())
+        fund_ref = "fundref"
+        valid_schemes.add(fund_ref)
+        for scheme, identifier in record.get("external_ids", {}).items():
+            scheme = scheme.lower()
+            if scheme in valid_schemes:
+                value = identifier.get("preferred") or identifier.get("all")[0]
+                if scheme == fund_ref:
+                    value = f"{funder_fundref_doi_prefix}/{value}"
+                    scheme = "doi"
+
+                funder["identifiers"].append({
+                    "identifier": value,
+                    "scheme": scheme,
+                })
+
+        stream_entry.entry = funder
+        return stream_entry
+
+
+VOCABULARIES_DATASTREAM_TRANSFORMERS = {
+    "ror-funder": RORTransformer,
+}
+"""ORCiD Data Streams transformers."""
+
+
+VOCABULARIES_DATASTREAM_WRITERS = {
+    "funders-service": FundersServiceWriter,
+}
+"""ORCiD Data Streams transformers."""
+
+
+DATASTREAM_CONFIG = {
+    "readers": [
+        {
+            "type": "zip",
+            "args": {
+                "regex": ".json$",
+            }
+        },
+        {"type": "json"}
+    ],
+    "transformers": [
+        {"type": "ror-funder"},
+    ],
+    "writers": [{
+        "type": "funders-service",
+        "args": {
+            "service_or_name": "rdm-funders",
+            "identity": system_identity,
+        }
+    }],
+}
+"""Data Stream configuration.
+
+An origin is required for the reader.
+"""

--- a/invenio_vocabularies/contrib/funders/datastreams.py
+++ b/invenio_vocabularies/contrib/funders/datastreams.py
@@ -75,13 +75,13 @@ class RORTransformer(BaseTransformer):
 VOCABULARIES_DATASTREAM_TRANSFORMERS = {
     "ror-funder": RORTransformer,
 }
-"""ORCiD Data Streams transformers."""
+"""ROR Data Streams transformers."""
 
 
 VOCABULARIES_DATASTREAM_WRITERS = {
     "funders-service": FundersServiceWriter,
 }
-"""ORCiD Data Streams transformers."""
+"""Funders Data Streams transformers."""
 
 
 DATASTREAM_CONFIG = {

--- a/invenio_vocabularies/contrib/names/datastreams.py
+++ b/invenio_vocabularies/contrib/names/datastreams.py
@@ -137,12 +137,14 @@ VOCABULARIES_DATASTREAM_WRITERS = {
 
 
 DATASTREAM_CONFIG = {
-    "reader": {
-        "type": "tar",
-        "args": {
-            "regex": ".xml$",
+    "readers": [
+        {
+            "type": "tar",
+            "args": {
+                "regex": ".xml$",
+            }
         }
-    },
+    ],
     "transformers": [
         {"type": "xml"},
         {"type": "orcid"}

--- a/invenio_vocabularies/datastreams/datastreams.py
+++ b/invenio_vocabularies/datastreams/datastreams.py
@@ -31,7 +31,7 @@ class DataStream:
         :param writers: an ordered list of writers.
         :param transformers: an ordered list of transformers to apply.
         """
-        self._readers = readers  # a single entry point
+        self._readers = readers
         self._transformers = transformers
         self._writers = writers
 
@@ -48,14 +48,17 @@ class DataStream:
         writing it.
         """
         for stream_entry in self.read():
-            transformed_entry = self.transform(stream_entry)
-            if transformed_entry.errors:
-                yield transformed_entry
-            elif self.filter(transformed_entry):
-                transformed_entry.filtered = True
-                yield transformed_entry
+            if stream_entry.errors:
+                yield stream_entry  # reading errors
             else:
-                yield self.write(transformed_entry)
+                transformed_entry = self.transform(stream_entry)
+                if transformed_entry.errors:
+                    yield transformed_entry
+                elif self.filter(transformed_entry):
+                    transformed_entry.filtered = True
+                    yield transformed_entry
+                else:
+                    yield self.write(transformed_entry)
 
     def read(self):
         """Recursively read the entries."""

--- a/invenio_vocabularies/datastreams/factories.py
+++ b/invenio_vocabularies/datastreams/factories.py
@@ -68,10 +68,13 @@ class DataStreamFactory:
 
     @classmethod
     def create(
-        cls, reader_config, writers_config, transformers_config=None, **kwargs
+        cls, readers_config, writers_config, transformers_config=None, **kwargs
     ):
         """Creates a data stream based on the config."""
-        reader = ReaderFactory.create(reader_config)
+        readers = []
+        for r_conf in readers_config:
+            readers.append(ReaderFactory.create(r_conf))
+
         writers = []
         for w_conf in writers_config:
             writers.append(WriterFactory.create(w_conf))
@@ -82,5 +85,5 @@ class DataStreamFactory:
                 transformers.append(TransformerFactory.create(t_conf))
 
         return DataStream(
-            reader=reader, writers=writers, transformers=transformers
+            readers=readers, writers=writers, transformers=transformers
         )

--- a/invenio_vocabularies/datastreams/readers.py
+++ b/invenio_vocabularies/datastreams/readers.py
@@ -130,8 +130,11 @@ class JsonReader(BaseReader):
         def _read(file):
             try:
                 entries = json.load(file)
-                for entry in entries:
-                    yield entry
+                if isinstance(entries, list):
+                    for entry in entries:
+                        yield entry
+                else:
+                    yield entries  # just one entry
             except JSONDecodeError as err:
                 raise ReaderError(
                     f"Cannot decode JSON file {file.name}: {str(err)}"

--- a/invenio_vocabularies/fixtures.py
+++ b/invenio_vocabularies/fixtures.py
@@ -25,7 +25,7 @@ class VocabularyFixture:
     def _load_vocabulary(self, config, delay=True, **kwargs):
         """Given an entry from the vocabularies.yaml file, load its content."""
         datastream = DataStreamFactory.create(
-            reader_config=config["reader"],
+            readers_config=config["readers"],
             transformers_config=config.get("transformers"),
             writers_config=config["writers"],
         )

--- a/invenio_vocabularies/services/schema.py
+++ b/invenio_vocabularies/services/schema.py
@@ -48,7 +48,11 @@ class DatastreamObject(Schema):
 class TaskSchema(Schema):
     """Service schema for vocabulary tasks."""
 
-    reader = fields.Nested(DatastreamObject, required=True)
+    readers = fields.List(
+        fields.Nested(DatastreamObject),
+        validate=validate.Length(min=1),
+        required=True,
+    )
     transformers = fields.List(
         fields.Nested(DatastreamObject),
         validate=validate.Length(min=1),

--- a/invenio_vocabularies/services/tasks.py
+++ b/invenio_vocabularies/services/tasks.py
@@ -17,7 +17,7 @@ from ..datastreams.factories import DataStreamFactory
 def process_datastream(config):
     """Process a datastream from config."""
     ds = DataStreamFactory.create(
-        reader_config=config["reader"],
+        readers_config=config["readers"],
         transformers_config=config.get("transformers"),
         writers_config=config["writers"],
     )

--- a/tests/contrib/funders/test_funders_datastreams.py
+++ b/tests/contrib/funders/test_funders_datastreams.py
@@ -1,0 +1,176 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Funders datastreams tests."""
+
+from copy import deepcopy
+
+import pytest
+from invenio_access.permissions import system_identity
+
+from invenio_vocabularies.contrib.funders.api import Funder
+from invenio_vocabularies.contrib.funders.datastreams import \
+    FundersServiceWriter, RORTransformer
+from invenio_vocabularies.datastreams import StreamEntry
+from invenio_vocabularies.datastreams.errors import WriterError
+
+
+@pytest.fixture(scope="module")
+def base_app(base_app, service):
+    """Application factory fixture."""
+    registry = base_app.extensions["invenio-records-resources"].registry
+    registry.register(service, service_id="rdm-funders")
+
+    yield base_app
+
+
+@pytest.fixture(scope="module")
+def dict_ror_entry():
+    return StreamEntry({
+        "id": "https://ror.org/0aaaaaa11",
+        "name": "Funder",
+        "types": [
+            "Facility"
+        ],
+        "links": [
+            "http://test.com"
+        ],
+        "aliases": [],
+        "acronyms": [
+            "FND"
+        ],
+        "status": "active",
+        "wikipedia_url": "https://en.wikipedia.org/wiki/FUNDER_TEST",
+        "labels": [
+            {
+                "label": "Funder",
+                "iso639": "en"
+            },
+            {
+                "label": "Geldgeber",
+                "iso639": "de"
+            }
+        ],
+        "email_address": None,
+        "ip_addresses": [],
+        "established": 1954,
+        "country": {
+            "country_code": "GR",
+            "country_name": "Greece"
+        },
+        "relationships": [],
+
+        "external_ids": {
+            "ISNI": {
+                "preferred": None,
+                "all": [
+                    "0000 0001 2156 142X"
+                ]
+            },
+            "GRID": {
+                "preferred": "grid.9132.9",
+                "all": "grid.9132.9"
+            },
+            "FundRef": {
+                "preferred": "000000000000",
+                "all": []
+            }
+        }
+    })
+
+
+@pytest.fixture(scope="module")
+def expected_from_ror_json():
+    return {
+        "pid": "0aaaaaa11",
+        "name": "Funder",
+        "title": {"en": "Funder", "de": "Geldgeber"},
+        "country": "GR",
+        "identifiers": [
+            {
+                "scheme": "isni",
+                "identifier": "0000 0001 2156 142X"
+            }, {
+                "scheme": "grid",
+                "identifier": "grid.9132.9"
+            }, {
+                "scheme": "doi",
+                "identifier": "10.13039/000000000000"
+            }
+        ],
+    }
+
+
+def test_ror_transformer(app, dict_ror_entry, expected_from_ror_json):
+    transformer = RORTransformer()
+    assert expected_from_ror_json == transformer.apply(dict_ror_entry).entry
+
+
+def test_funders_service_writer_create(app, es_clear, funder_full_data):
+    writer = FundersServiceWriter("rdm-funders", system_identity)
+    funder_rec = writer.write(StreamEntry(funder_full_data))
+    funder_dict = funder_rec.entry.to_dict()
+    assert dict(funder_dict, **funder_full_data) == funder_dict
+
+    # not-ideal cleanup
+    funder_rec.entry._record.delete(force=True)
+
+
+def test_funders_service_writer_duplicate(app, es_clear, funder_full_data):
+    writer = FundersServiceWriter("rdm-funders", system_identity)
+    funder_rec = writer.write(stream_entry=StreamEntry(funder_full_data))
+    Funder.index.refresh()  # refresh index to make changes live
+    with pytest.raises(WriterError) as err:
+        writer.write(stream_entry=StreamEntry(funder_full_data))
+
+    expected_error = [f"Vocabulary entry already exists: {funder_full_data}"]
+    assert expected_error in err.value.args
+
+    # not-ideal cleanup
+    funder_rec.entry._record.delete(force=True)
+
+
+def test_funders_service_writer_update_existing(
+    app, es_clear, funder_full_data, service
+):
+    # create vocabulary
+    writer = FundersServiceWriter("rdm-funders", system_identity, update=True)
+    orig_funder_rec = writer.write(stream_entry=StreamEntry(funder_full_data))
+    Funder.index.refresh()  # refresh index to make changes live
+    # update vocabulary
+    updated_funder = deepcopy(funder_full_data)
+    updated_funder["name"] = "Updated Name"
+    # check changes vocabulary
+    _ = writer.write(stream_entry=StreamEntry(updated_funder))
+    funder_rec = service.read(system_identity, orig_funder_rec.entry.id)
+    funder_dict = funder_rec.to_dict()
+
+    # needed while the writer resolves from ES
+    assert _.entry.id == orig_funder_rec.entry.id
+    assert dict(funder_dict, **updated_funder) == funder_dict
+
+    # not-ideal cleanup
+    funder_rec._record.delete(force=True)
+
+
+def test_funders_service_writer_update_non_existing(
+    app, es_clear, funder_full_data, service
+):
+    # vocabulary item not created, call update directly
+    updated_funder = deepcopy(funder_full_data)
+    updated_funder["name"] = "New name"
+    # check changes vocabulary
+    writer = FundersServiceWriter("rdm-funders", system_identity, update=True)
+    funder_rec = writer.write(stream_entry=StreamEntry(updated_funder))
+    funder_rec = service.read(system_identity, funder_rec.entry.id)
+    funder_dict = funder_rec.to_dict()
+
+    assert dict(funder_dict, **updated_funder) == funder_dict
+
+    # not-ideal cleanup
+    funder_rec._record.delete(force=True)

--- a/tests/contrib/funders/test_funders_resource.py
+++ b/tests/contrib/funders/test_funders_resource.py
@@ -86,7 +86,7 @@ def example_funders(service, identity, indexer):
             }
         },
         {
-            "pid": "aaaaaa11",
+            "pid": "0aaaaaa11",
             "name": "OTHER",
             "country": "CH",
             "title": {
@@ -94,7 +94,7 @@ def example_funders(service, identity, indexer):
             }
         },
         {
-            "pid": "aaaaaa22",
+            "pid": "0aaaaaa22",
             "name": "CERT",
             "country": "CH",
             "title": {

--- a/tests/contrib/names/test_names_datastreams.py
+++ b/tests/contrib/names/test_names_datastreams.py
@@ -117,9 +117,9 @@ XML_ENTRY_DATA = bytes(
 
 
 @pytest.fixture(scope='function')
-def bytes_xml_entry():
+def bytes_xml_data():
     # simplified version of an XML file of the ORCiD dump
-    return StreamEntry(XML_ENTRY_DATA)
+    return XML_ENTRY_DATA
 
 
 @pytest.fixture(scope="module")
@@ -168,15 +168,14 @@ class MockResponse():
 
 
 @patch('requests.get', side_effect=lambda url, headers: MockResponse())
-def test_orcid_http_reader(_, bytes_xml_entry):
+def test_orcid_http_reader(_, bytes_xml_data):
     reader = OrcidHTTPReader(id="0000-0001-8135-3489")
     results = []
     for entry in reader.read():
         results.append(entry)
 
     assert len(results) == 1
-    assert bytes_xml_entry.entry == results[0].entry
-    assert not results[0].errors
+    assert bytes_xml_data == results[0]
 
 
 def test_names_service_writer_create(app, es_clear, name_full_data):

--- a/tests/datastreams/conftest.py
+++ b/tests/datastreams/conftest.py
@@ -29,10 +29,14 @@ from invenio_vocabularies.datastreams.writers import BaseWriter
 class TestReader(BaseReader):
     """Test reader."""
 
-    def read(self, *args, **kwargs):
+    def _iter(self, fp, *args, **kwargs):
         """Yields the values in the origin."""
         for value in self._origin:
             yield value
+
+    def read(self, item=None, *args, **kwargs):
+        """Reads from item or opens the file descriptor from origin."""
+        yield from self._iter(fp=self._origin, *args, **kwargs)
 
 
 class TestTransformer(BaseTransformer):

--- a/tests/datastreams/conftest.py
+++ b/tests/datastreams/conftest.py
@@ -89,8 +89,8 @@ def app_config(app_config):
 
 
 @pytest.fixture(scope='module')
-def expected_from_zip():
-    """Creates a zip file."""
+def json_list():
+    """Expected json list."""
     return [
         {
             "test": {
@@ -105,8 +105,18 @@ def expected_from_zip():
     ]
 
 
+@pytest.fixture(scope='module')
+def json_element():
+    """Expected json element."""
+    return {
+        "test": {
+            "inner": "value"
+        }
+    }
+
+
 @pytest.fixture(scope='function')
-def zip_file(expected_from_zip):
+def zip_file(json_list):
     """Creates a Zip file with three files (two json) inside.
 
     Each iteration should return the content of one json file,
@@ -118,20 +128,10 @@ def zip_file(expected_from_zip):
         for file_ in files:
             inner_filename = Path(file_)
             with open(inner_filename, 'w') as file:
-                json.dump(expected_from_zip, file)
+                json.dump(json_list, file)
             archive.write(inner_filename)
             inner_filename.unlink()
 
     yield filename
 
     filename.unlink()  # delete created file
-
-
-@pytest.fixture(scope='module')
-def expected_from_json():
-    """Expected json string."""
-    return [{
-        "test": {
-            "inner": "value"
-        }
-    }]

--- a/tests/datastreams/test_datastreams.py
+++ b/tests/datastreams/test_datastreams.py
@@ -80,7 +80,7 @@ def test_base_datastream_fail_on_write(app, vocabulary_config):
 
 
 @pytest.fixture(scope='function')
-def zip_file(expected_from_zip):
+def zip_file(json_list):
     """Creates a Zip file with three files inside.
 
     The first file should return two json elements.
@@ -91,7 +91,7 @@ def zip_file(expected_from_zip):
     def _correct_file(archive, idx):
         correct_file = Path(f"correct_{idx}.json")
         with open(correct_file, 'w') as file:
-            json.dump(expected_from_zip, file)
+            json.dump(json_list, file)
         archive.write(correct_file)
         correct_file.unlink()
 
@@ -113,7 +113,7 @@ def zip_file(expected_from_zip):
     filename.unlink()  # delete created file
 
 
-def test_piping_readers(app, zip_file, expected_from_json):
+def test_piping_readers(app, zip_file, json_element):
     ds_config = {
         "readers": [
             {
@@ -141,7 +141,7 @@ def test_piping_readers(app, zip_file, expected_from_json):
     iter = datastream.process()
     for count, entry in enumerate(iter, start=1):
         if count != 3:
-            assert entry.entry == expected_from_json[0]
+            assert entry.entry == json_element
         else:
             # assert the second file fails
             assert entry.entry.name == "errored.json"

--- a/tests/datastreams/test_readers.py
+++ b/tests/datastreams/test_readers.py
@@ -93,34 +93,53 @@ def test_tar_reader(tar_file, expected_from_tar):
     assert total == 2  # ignored the `.other` file
 
 
-def test_zip_reader(zip_file, expected_from_zip):
+def test_zip_reader(zip_file, json_list):
     reader = ZipReader(zip_file, regex=".json$")
     total = 0
     for data in reader.read():
-        assert json.load(data) == expected_from_zip
+        assert json.load(data) == json_list
         total += 1
 
     assert total == 2  # ignored the `.other` file
 
 
 @pytest.fixture(scope='function')
-def json_file(expected_from_json):
-    """Creates a Json file.
-
-    """
+def json_list_file(json_list):
+    """Creates a JSON file with an array inside."""
     filename = Path("reader_test.json")
     with open(filename, mode='w') as file:
-        json.dump(expected_from_json, file)
+        json.dump(json_list, file)
 
     yield filename
 
     filename.unlink()  # delete created file
 
 
-def test_json_reader(json_file, expected_from_json):
-    reader = JsonReader(json_file, regex=".json$")
+def test_json_list_reader(json_list_file, json_element):
+    reader = JsonReader(json_list_file, regex=".json$")
 
-    for data in reader.read():
-        assert data == expected_from_json[0]
+    for count, data in enumerate(reader.read(), start=1):
+        assert data == json_element
+
+    assert count == 2
+
+
+@pytest.fixture(scope='function')
+def json_element_file(json_element):
+    """Creates a JSON file with only one element inside."""
+    filename = Path("reader_test.json")
+    with open(filename, mode='w') as file:
+        json.dump(json_element, file)
+    yield filename
+    filename.unlink()  # delete created file
+
+
+def test_json_element_reader(json_element_file, json_element):
+    reader = JsonReader(json_element_file, regex=".json$")
+
+    for count, data in enumerate(reader.read(), start=1):
+        assert data == json_element
+
+    assert count == 1
 
 # FIXME: add test for csv reader

--- a/tests/datastreams/vocabularies.yaml
+++ b/tests/datastreams/vocabularies.yaml
@@ -2,20 +2,20 @@ testone:
   pid-type: testid
   transformers:
     - type: test
-  reader:
-    type: test
-    args:
-      origin: [-1, 2, 3]
+  readers:
+    - type: test
+      args:
+        origin: [-1, 2, 3]
   writers:
     - type: test
 testtwo:
   pid-type: testit
   transformers:
     - type: test
-  reader:
-    type: test
-    args:
-      origin: [1, 2, 3]
+  readers:
+    - type: test
+      args:
+        origin: [1, 2, 3]
   writers:
     - type: fail
       args:

--- a/tests/resources/test_tasks_resources.py
+++ b/tests/resources/test_tasks_resources.py
@@ -25,7 +25,7 @@ class TestReader(BaseReader):
     # no need for self since it is patched
     def read(*args, **kwargs):
         """Yields empty dict."""
-        yield StreamEntry(1)
+        yield 1
 
 
 class TestTransformer(BaseTransformer):
@@ -65,12 +65,12 @@ def app_config(app_config):
 def test_task_creation(app, client_with_credentials, h):
     client = client_with_credentials
     task_config = {
-        "reader": {
+        "readers": [{
             "type": "test",
             "args": {
                 "origin": "somewhere"
             }
-        },
+        }],
         "transformers": [{"type": "test"}],
         "writers": [{"type": "test"}]
     }

--- a/tests/resources/test_tasks_resources.py
+++ b/tests/resources/test_tasks_resources.py
@@ -22,9 +22,12 @@ from invenio_vocabularies.datastreams.writers import BaseWriter
 class TestReader(BaseReader):
     """Test reader."""
 
-    # no need for self since it is patched
-    def read(*args, **kwargs):
-        """Yields empty dict."""
+    # needs implementation due to abstract decorator in the base class
+    def _iter(self, fp, *args, **kwargs):
+        pass
+
+    def read(self, item=None, *args, **kwargs):
+        """Reads from item or opens the file descriptor from origin."""
         yield 1
 
 

--- a/tests/services/test_schema.py
+++ b/tests/services/test_schema.py
@@ -16,9 +16,9 @@ from invenio_vocabularies.services.schema import TaskSchema
 
 def test_valid_minimal():
     valid_minimal = {
-        "reader": {
+        "readers": [{
             "type": "test"
-        },
+        }],
         "writers": [{"type": "test"}]
     }
     assert valid_minimal == TaskSchema().load(valid_minimal)
@@ -26,13 +26,13 @@ def test_valid_minimal():
 
 def test_valid_full():
     valid_full = {
-        "reader": {
+        "readers": [{
             "type": "test",
             "args": {
                 "one": 1,
                 "two": "two"
             }
-        },
+        }],
         "transformers": [{
             "type": "test",
             "args": {
@@ -66,23 +66,23 @@ def test_valid_full():
 @pytest.mark.parametrize("invalid", [
     {},
     {
-        "reader": [{"type": "test"}, {"type": "testtoo"}],
-        "writers": [{"type": "test"}]
+        "readers": {"type": "test"},  # non-list readers
+        "writers": [{"type": "test"}],
     },
     {
-        "reader": {"type": "testtoo"},
-        "writers": {"type": "test"}
+        "readers": [{"type": "testtoo"}],
+        "writers": {"type": "test"},  # non-list writers
     },
     {
-        "reader": {"type": "testtoo"},
-        "transformers": {"type": "test"},
-        "writers": [{"type": "test"}]
+        "readers": [{"type": "testtoo"}],
+        "transformers": {"type": "test"},   # non-list transformers
+        "writers": [{"type": "test"}],
     },
     {
-        "reader": {"type": "testtoo"},
+        "readers": [{"type": "testtoo"}],  # no writers
     },
     {
-        "writers": [{"type": "test"}]
+        "writers": [{"type": "test"}],  # no readers
     },
 ])
 def test_invalid_empty(invalid):


### PR DESCRIPTION
requires https://github.com/inveniosoftware/invenio-vocabularies/pull/155
closes https://github.com/inveniosoftware/invenio-vocabularies/issues/148

Example imported from the dump:

```json
{
        "pid": "04j757h98",
        "name": "Victoria University",
        "created": "2022-03-21T16:11:03.049346+00:00",
        "id": "a73cad48-a30b-4cc7-b4aa-366a201a2029",
        "country": "AU",
        "title": {},
        "links": {
          "self": "https://127.0.0.1:5000/api/funders/04j757h98"
        },
        "updated": "2022-03-21T16:11:03.059741+00:00",
        "identifiers": [
          {
            "scheme": "isni",
            "identifier": "0000 0001 0396 9544"
          },
          {
            "scheme": "doi",
            "identifier": "10.13039/501100001784"
          },
          {
            "scheme": "grid",
            "identifier": "grid.1019.9"
          }
        ],
        "revision_id": 2
      }
```

Rebasing multiple PRs has created a bit of conflicts, should be solved once the required PRs are merged. Tests are passing in local:

<img width="520" alt="Screenshot 2022-03-21 at 17 26 20" src="https://user-images.githubusercontent.com/6756943/159305891-71f54347-0907-4b06-b88b-fe77dba3757b.png">

