### PR TITLE
Awards facets

### DIFF
--- a/invenio_vocabularies/contrib/awards/config.py
+++ b/invenio_vocabularies/contrib/awards/config.py
@@ -9,7 +9,6 @@
 """Vocabulary awards configuration."""
 
 from flask import current_app
-from flask_babelex import lazy_gettext as _
 from invenio_records_resources.services import SearchOptions
 from invenio_records_resources.services.records.components import DataComponent
 from invenio_records_resources.services.records.params import \

--- a/invenio_vocabularies/contrib/funders/facets.py
+++ b/invenio_vocabularies/contrib/funders/facets.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Vocabulary awards facets and labels."""
+
+from ...services.facets import VocabularyLabels, lazy_get_label
+
+
+class FundersLabels(VocabularyLabels):
+    """Fetching of vocabulary labels for facets."""
+
+    def __init__(self, vocabulary, cache=False, service_name=None):
+        """Initialize the labels."""
+        super().__init__(
+            vocabulary, cache, service_name="funders-service", id_field="pid"
+        )
+        self.fields = ["pid", "title", "country"]  # not configurable
+
+    def _vocab_to_label(self, vocab):
+        """Returns the label string for a vocabulary entry."""
+        return f"{lazy_get_label(vocab['title'])} ({vocab['country']})"

--- a/invenio_vocabularies/contrib/funders/services.py
+++ b/invenio_vocabularies/contrib/funders/services.py
@@ -8,8 +8,24 @@
 
 """Vocabulary affiliations."""
 
+from elasticsearch_dsl.query import Q
+
 from .funders import record_type
 
 FundersServiceConfig = record_type.service_config_cls
 
-FundersService = record_type.service_cls
+
+class FundersService(record_type.service_cls):
+    """Funders service."""
+
+    def read_many(self, identity, ids, fields=None, **kwargs):
+        """Search for records matching the ids."""
+        clauses = []
+        for id_ in ids:
+            clauses.append(Q('term', **{"pid": id_}))
+        query = Q('bool', minimum_should_match=1, should=clauses)
+
+        results = self._read_many(
+            identity, query, fields, len(ids), **kwargs)
+
+        return self.result_list(self, identity, results)

--- a/tests/contrib/awards/conftest.py
+++ b/tests/contrib/awards/conftest.py
@@ -13,14 +13,22 @@ fixtures are available.
 """
 
 import pytest
+from flask_babelex import lazy_gettext as _
 from invenio_indexer.api import RecordIndexer
+from invenio_records_resources.services.records.facets import TermsFacet
 
 from invenio_vocabularies.contrib.awards.api import Award
+from invenio_vocabularies.contrib.awards.config import AwardsSearchOptions
 from invenio_vocabularies.contrib.awards.resources import AwardsResource, \
     AwardsResourceConfig
 from invenio_vocabularies.contrib.awards.services import AwardsService, \
     AwardsServiceConfig
 from invenio_vocabularies.contrib.funders.api import Funder
+from invenio_vocabularies.contrib.funders.facets import FundersLabels
+from invenio_vocabularies.contrib.funders.resources import FundersResource, \
+    FundersResourceConfig
+from invenio_vocabularies.contrib.funders.services import FundersService, \
+    FundersServiceConfig
 
 
 @pytest.fixture(scope="module")
@@ -29,20 +37,66 @@ def extra_entry_points():
     return {
         "invenio_db.models": [
             "awards = invenio_vocabularies.contrib.awards.models",
+            "funders = invenio_vocabularies.contrib.funders.models",
         ],
         "invenio_jsonschemas.schemas": [
-            "awards = \
-                invenio_vocabularies.contrib.awards.jsonschemas",
-            "funders = \
-                invenio_vocabularies.contrib.funders.jsonschemas"
+            "awards = invenio_vocabularies.contrib.awards.jsonschemas",
+            "funders = invenio_vocabularies.contrib.funders.jsonschemas"
         ],
         "invenio_search.mappings": [
-            "awards = \
-                invenio_vocabularies.contrib.awards.mappings",
+            "awards = invenio_vocabularies.contrib.awards.mappings",
+            "funders = invenio_vocabularies.contrib.funders.mappings",
         ]
     }
 
 
+#
+# Funder related fixtures
+#
+@pytest.fixture(scope="function")
+def example_funder(db, identity, funders_service, funder_indexer):
+    """Example funder."""
+    funder_data = {
+        "pid": "01ggx4157",
+        "name": "CERN",
+        "title": {
+            "en": "European Organization for Nuclear Research",
+            "fr": "Organisation européenne pour la recherche nucléaire"
+        },
+        "country": "CH"
+    }
+    fun = funders_service.create(identity, funder_data)
+    Funder.index.refresh()  # Refresh the index
+    yield fun
+    fun._record.delete(force=True)
+    funder_indexer.delete(fun._record, refresh=True)
+    db.session.commit()
+
+
+@pytest.fixture()
+def funder_indexer():
+    """Indexer instance with correct Record class."""
+    return RecordIndexer(
+        record_cls=Funder,
+        record_to_index=lambda r: (r.__class__.index._name, "_doc"),
+    )
+
+
+@pytest.fixture(scope='module')
+def funders_service():
+    """Funders service object."""
+    return FundersService(config=FundersServiceConfig)
+
+
+@pytest.fixture(scope="module")
+def funders_resource(service):
+    """Funders resource object."""
+    return FundersResource(FundersResourceConfig, service)
+
+
+#
+# Award related fixtures
+#
 @pytest.fixture(scope="function")
 def award_full_data():
     """Full award data."""
@@ -80,26 +134,6 @@ def example_award(
     db.session.commit()
 
 
-@pytest.fixture(scope="function")
-def example_funder(db):
-    """Example funder."""
-    api_funder = {
-        "name": "CERN",
-        "title": {
-            "en": "European Organization for Nuclear Research",
-            "fr": "Organisation européenne pour la recherche nucléaire"
-        },
-        "country": "CH"
-    }
-    # at API level 'pid' is passed as an arg
-    fun = Funder.create(api_funder, pid="01ggx4157")
-    fun.commit()
-    db.session.commit()
-    yield fun
-    fun.delete(force=True)
-    db.session.commit()
-
-
 @pytest.fixture()
 def indexer():
     """Indexer instance with correct Record class."""
@@ -112,7 +146,23 @@ def indexer():
 @pytest.fixture(scope='module')
 def service():
     """Awards service object."""
-    return AwardsService(config=AwardsServiceConfig)
+    class MockAwardsSearchOptions(AwardsSearchOptions):
+        """Mock search options to add funders facet."""
+
+        facets = {
+            'funders': TermsFacet(
+                field='funder.id',
+                label=_('Funders'),
+                value_labels=FundersLabels('funders')
+            )
+        }
+
+    class MockAwardsServiceConfig(AwardsServiceConfig):
+        """Mock resource config to add funders facet."""
+
+        search = MockAwardsSearchOptions
+
+    return AwardsService(config=MockAwardsServiceConfig)
 
 
 @pytest.fixture(scope="module")
@@ -122,12 +172,14 @@ def resource(service):
 
 
 @pytest.fixture(scope="module")
-def base_app(base_app, resource, service):
+def base_app(base_app, resource, service, funders_resource, funders_service):
     """Application factory fixture.
 
     Registers awards' resource and service.
     """
+    base_app.register_blueprint(funders_resource.as_blueprint())
     base_app.register_blueprint(resource.as_blueprint())
     registry = base_app.extensions['invenio-records-resources'].registry
+    registry.register(funders_service, service_id='funders-service')
     registry.register(service, service_id='awards-service')
     yield base_app


### PR DESCRIPTION
- requires #163 
- closes https://github.com/inveniosoftware/invenio-vocabularies/issues/168 

## Changes

- Enable customization of service used to get the vocabularies when calculating the facet labels.
- Enable customization of the label string (i.e. not just `title`).
- Implements a `FundersLabels`, with the corresponding changes in `service.read_many`.