### PR TITLE
OpenSearch 2.x

### DIFF
--- a/.github/workflows/tests-feature.yaml
+++ b/.github/workflows/tests-feature.yaml
@@ -31,13 +31,13 @@ jobs:
         requirements-level: [pypi]
         cache-service: [redis]
         db-service: [postgresql13]
-        search-service: [opensearch1,elasticsearch7]
+        search-service: [opensearch2,elasticsearch7]
         include:
           - db-service: postgresql13
             DB_EXTRAS: "postgresql"
 
-          - search-service: opensearch1
-            SEARCH_EXTRAS: "opensearch1"
+          - search-service: opensearch2
+            SEARCH_EXTRAS: "opensearch2"
 
           - search-service: elasticsearch7
             SEARCH_EXTRAS: "elasticsearch7"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,14 +34,14 @@ jobs:
         python-version: [3.7, 3.8, 3.9]
         requirements-level: [pypi]
         db-service: [postgresql10, postgresql13]
-        search-service: [opensearch1,elasticsearch7]
+        search-service: [opensearch2,elasticsearch7]
         exclude:
           - python-version: 3.7
             db-service: postgresql13
 
         include:
-          - search-service: opensearch1
-            SEARCH_EXTRAS: "opensearch1"
+          - search-service: opensearch2
+            SEARCH_EXTRAS: "opensearch2"
 
           - search-service: elasticsearch7
             SEARCH_EXTRAS: "elasticsearch7"

--- a/invenio_vocabularies/contrib/affiliations/mappings/os-v1/affiliations/affiliation-v1.0.0.json
+++ b/invenio_vocabularies/contrib/affiliations/mappings/os-v1/affiliations/affiliation-v1.0.0.json
@@ -1,5 +1,16 @@
 {
   "mappings": {
+    "dynamic_templates": [
+      {
+        "i18n_title": {
+          "path_match": "title.*",
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "search_as_you_type"
+          }
+        }
+      }
+    ],
     "dynamic": "strict",
     "properties": {
       "$schema": {
@@ -73,12 +84,7 @@
       },
       "title": {
         "type": "object",
-        "dynamic": true,
-        "properties": {
-          "en": {
-            "type": "search_as_you_type"
-          }
-        }
+        "dynamic": true
       }
     }
   }

--- a/invenio_vocabularies/contrib/affiliations/mappings/os-v2/__init__.py
+++ b/invenio_vocabularies/contrib/affiliations/mappings/os-v2/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Affiliations OpenSearch v2 mappings."""

--- a/invenio_vocabularies/contrib/affiliations/mappings/os-v2/affiliations/affiliation-v1.0.0.json
+++ b/invenio_vocabularies/contrib/affiliations/mappings/os-v2/affiliations/affiliation-v1.0.0.json
@@ -1,0 +1,85 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "$schema": {
+        "type": "keyword",
+        "index": "false"
+      },
+      "created": {
+        "type": "date"
+      },
+      "updated": {
+        "type": "date"
+      },
+      "indexed_at": {
+        "type": "date"
+      },
+      "uuid": {
+        "type": "keyword"
+      },
+      "version_id": {
+        "type": "integer"
+      },
+      "id": {
+        "type": "keyword"
+      },
+      "name_sort": {
+        "type": "keyword"
+      },
+      "name": {
+        "type": "text",
+        "copy_to": "name_sort",
+        "fields": {
+          "suggest": {
+            "type": "search_as_you_type"
+          }
+        }
+      },
+      "acronym": {
+        "type": "text",
+        "fields": {
+          "suggest": {
+            "type": "search_as_you_type"
+          }
+        }
+      },
+      "identifiers": {
+        "properties": {
+          "identifier": {
+            "type": "keyword"
+          },
+          "scheme": {
+            "type": "keyword"
+          }
+        }
+      },
+      "pid": {
+        "type": "object",
+        "properties": {
+          "pk": {
+            "type": "integer"
+          },
+          "pid_type": {
+            "type": "keyword"
+          },
+          "obj_type": {
+            "type": "keyword"
+          },
+          "status": {
+            "type": "keyword"
+          }
+        }
+      },
+      "title": {
+        "type": "object",
+        "dynamic": true,
+        "properties": {
+          "en": {
+            "type": "search_as_you_type"
+          }
+        }
+      }
+    }
+  }
+}

--- a/invenio_vocabularies/contrib/affiliations/mappings/os-v2/affiliations/affiliation-v1.0.0.json
+++ b/invenio_vocabularies/contrib/affiliations/mappings/os-v2/affiliations/affiliation-v1.0.0.json
@@ -1,5 +1,16 @@
 {
   "mappings": {
+    "dynamic_templates": [
+      {
+        "i18n_title": {
+          "path_match": "title.*",
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "search_as_you_type"
+          }
+        }
+      }
+    ],
     "dynamic": "strict",
     "properties": {
       "$schema": {
@@ -73,12 +84,7 @@
       },
       "title": {
         "type": "object",
-        "dynamic": true,
-        "properties": {
-          "en": {
-            "type": "search_as_you_type"
-          }
-        }
+        "dynamic": true
       }
     }
   }

--- a/invenio_vocabularies/contrib/affiliations/mappings/v7/affiliations/affiliation-v1.0.0.json
+++ b/invenio_vocabularies/contrib/affiliations/mappings/v7/affiliations/affiliation-v1.0.0.json
@@ -1,5 +1,16 @@
 {
   "mappings": {
+    "dynamic_templates": [
+      {
+        "i18n_title": {
+          "path_match": "title.*",
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "search_as_you_type"
+          }
+        }
+      }
+    ],
     "dynamic": "strict",
     "properties": {
       "$schema": {
@@ -73,12 +84,7 @@
       },
       "title": {
         "type": "object",
-        "dynamic": true,
-        "properties": {
-          "en": {
-            "type": "search_as_you_type"
-          }
-        }
+        "dynamic": true
       }
     }
   }

--- a/invenio_vocabularies/contrib/awards/mappings/os-v1/awards/award-v1.0.0.json
+++ b/invenio_vocabularies/contrib/awards/mappings/os-v1/awards/award-v1.0.0.json
@@ -1,5 +1,16 @@
 {
   "mappings": {
+    "dynamic_templates": [
+      {
+        "i18n_title": {
+          "path_match": "title.*",
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "search_as_you_type"
+          }
+        }
+      }
+    ],
     "dynamic": "strict",
     "properties": {
       "$schema": {
@@ -36,12 +47,7 @@
       },
       "title": {
         "type": "object",
-        "dynamic": true,
-        "properties": {
-          "en": {
-            "type": "search_as_you_type"
-          }
-        }
+        "dynamic": true
       },
       "number": {
         "type": "keyword"

--- a/invenio_vocabularies/contrib/awards/mappings/os-v2/__init__.py
+++ b/invenio_vocabularies/contrib/awards/mappings/os-v2/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Awards OpenSearch v2 mappings."""

--- a/invenio_vocabularies/contrib/awards/mappings/os-v2/awards/award-v1.0.0.json
+++ b/invenio_vocabularies/contrib/awards/mappings/os-v2/awards/award-v1.0.0.json
@@ -1,0 +1,68 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "$schema": {
+        "type": "keyword",
+        "index": "false"
+      },
+      "created": {
+        "type": "date"
+      },
+      "updated": {
+        "type": "date"
+      },
+      "indexed_at": {
+        "type": "date"
+      },
+      "uuid": {
+        "type": "keyword"
+      },
+      "version_id": {
+        "type": "integer"
+      },
+      "identifiers": {
+        "properties": {
+          "identifier": {
+            "type": "keyword"
+          },
+          "scheme": {
+            "type": "keyword"
+          }
+        }
+      },
+      "id": {
+        "type": "keyword"
+      },
+      "title": {
+        "type": "object",
+        "dynamic": true,
+        "properties": {
+          "en": {
+            "type": "search_as_you_type"
+          }
+        }
+      },
+      "number": {
+        "type": "keyword"
+      },
+      "acronym": {
+        "type": "keyword"
+      },
+      "funder": {
+        "type": "object",
+        "properties": {
+          "@v": {
+            "type": "keyword"
+          },
+          "id": {
+            "type": "keyword"
+          },
+          "name": {
+            "type": "text"
+          }
+        }
+      }
+    }
+  }
+}

--- a/invenio_vocabularies/contrib/awards/mappings/os-v2/awards/award-v1.0.0.json
+++ b/invenio_vocabularies/contrib/awards/mappings/os-v2/awards/award-v1.0.0.json
@@ -1,5 +1,16 @@
 {
   "mappings": {
+    "dynamic_templates": [
+      {
+        "i18n_title": {
+          "path_match": "title.*",
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "search_as_you_type"
+          }
+        }
+      }
+    ],
     "dynamic": "strict",
     "properties": {
       "$schema": {
@@ -36,12 +47,7 @@
       },
       "title": {
         "type": "object",
-        "dynamic": true,
-        "properties": {
-          "en": {
-            "type": "search_as_you_type"
-          }
-        }
+        "dynamic": true
       },
       "number": {
         "type": "keyword"

--- a/invenio_vocabularies/contrib/awards/mappings/v7/awards/award-v1.0.0.json
+++ b/invenio_vocabularies/contrib/awards/mappings/v7/awards/award-v1.0.0.json
@@ -1,5 +1,16 @@
 {
   "mappings": {
+    "dynamic_templates": [
+      {
+        "i18n_title": {
+          "path_match": "title.*",
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "search_as_you_type"
+          }
+        }
+      }
+    ],
     "dynamic": "strict",
     "properties": {
       "$schema": {
@@ -36,12 +47,7 @@
       },
       "title": {
         "type": "object",
-        "dynamic": true,
-        "properties": {
-          "en": {
-            "type": "search_as_you_type"
-          }
-        }
+        "dynamic": true
       },
       "number": {
         "type": "keyword"

--- a/invenio_vocabularies/contrib/funders/mappings/os-v1/funders/funder-v1.0.0.json
+++ b/invenio_vocabularies/contrib/funders/mappings/os-v1/funders/funder-v1.0.0.json
@@ -1,5 +1,16 @@
 {
   "mappings": {
+    "dynamic_templates": [
+      {
+        "i18n_title": {
+          "path_match": "title.*",
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "search_as_you_type"
+          }
+        }
+      }
+    ],
     "dynamic": "strict",
     "properties": {
       "$schema": {
@@ -51,12 +62,7 @@
       },
       "title": {
         "type": "object",
-        "dynamic": true,
-        "properties": {
-          "en": {
-            "type": "search_as_you_type"
-          }
-        }
+        "dynamic": true
       }
     }
   }

--- a/invenio_vocabularies/contrib/funders/mappings/os-v2/__init__.py
+++ b/invenio_vocabularies/contrib/funders/mappings/os-v2/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Funders OpenSearch v2 mappings."""

--- a/invenio_vocabularies/contrib/funders/mappings/os-v2/funders/funder-v1.0.0.json
+++ b/invenio_vocabularies/contrib/funders/mappings/os-v2/funders/funder-v1.0.0.json
@@ -1,0 +1,63 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "$schema": {
+        "type": "keyword",
+        "index": "false"
+      },
+      "created": {
+        "type": "date"
+      },
+      "updated": {
+        "type": "date"
+      },
+      "indexed_at": {
+        "type": "date"
+      },
+      "uuid": {
+        "type": "keyword"
+      },
+      "version_id": {
+        "type": "integer"
+      },
+      "identifiers": {
+        "properties": {
+          "identifier": {
+            "type": "keyword"
+          },
+          "scheme": {
+            "type": "keyword"
+          }
+        }
+      },
+      "name_sort": {
+        "type": "keyword"
+      },
+      "name": {
+        "type": "text",
+        "copy_to": "name_sort",
+        "fields": {
+          "suggest": {
+            "type": "search_as_you_type"
+          }
+        }
+      },
+      "country": {
+        "type": "text"
+      },
+      "id": {
+        "type": "keyword"
+      },
+      "title": {
+        "type": "object",
+        "dynamic": true,
+        "properties": {
+          "en": {
+            "type": "search_as_you_type"
+          }
+        }
+      }
+    }
+  }
+}

--- a/invenio_vocabularies/contrib/funders/mappings/os-v2/funders/funder-v1.0.0.json
+++ b/invenio_vocabularies/contrib/funders/mappings/os-v2/funders/funder-v1.0.0.json
@@ -1,5 +1,16 @@
 {
   "mappings": {
+    "dynamic_templates": [
+      {
+        "i18n_title": {
+          "path_match": "title.*",
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "search_as_you_type"
+          }
+        }
+      }
+    ],
     "dynamic": "strict",
     "properties": {
       "$schema": {
@@ -51,12 +62,7 @@
       },
       "title": {
         "type": "object",
-        "dynamic": true,
-        "properties": {
-          "en": {
-            "type": "search_as_you_type"
-          }
-        }
+        "dynamic": true
       }
     }
   }

--- a/invenio_vocabularies/contrib/funders/mappings/v7/funders/funder-v1.0.0.json
+++ b/invenio_vocabularies/contrib/funders/mappings/v7/funders/funder-v1.0.0.json
@@ -1,5 +1,16 @@
 {
   "mappings": {
+    "dynamic_templates": [
+      {
+        "i18n_title": {
+          "path_match": "title.*",
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "search_as_you_type"
+          }
+        }
+      }
+    ],
     "dynamic": "strict",
     "properties": {
       "$schema": {
@@ -51,12 +62,7 @@
       },
       "title": {
         "type": "object",
-        "dynamic": true,
-        "properties": {
-          "en": {
-            "type": "search_as_you_type"
-          }
-        }
+        "dynamic": true
       }
     }
   }

--- a/invenio_vocabularies/contrib/names/mappings/os-v2/__init__.py
+++ b/invenio_vocabularies/contrib/names/mappings/os-v2/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Names OpenSearch v2 mappings."""

--- a/invenio_vocabularies/contrib/names/mappings/os-v2/names/name-v1.0.0.json
+++ b/invenio_vocabularies/contrib/names/mappings/os-v2/names/name-v1.0.0.json
@@ -1,0 +1,98 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "$schema": {
+        "type": "keyword",
+        "index": "false"
+      },
+      "created": {
+        "type": "date"
+      },
+      "updated": {
+        "type": "date"
+      },
+      "indexed_at": {
+        "type": "date"
+      },
+      "uuid": {
+        "type": "keyword"
+      },
+      "version_id": {
+        "type": "integer"
+      },
+      "id": {
+        "type": "keyword"
+      },
+      "name_sort": {
+        "type": "keyword"
+      },
+      "name": {
+        "type": "text",
+        "copy_to": "name_sort",
+        "fields": {
+          "suggest": {
+            "type": "search_as_you_type"
+          }
+        }
+      },
+      "given_name": {
+        "type": "text"
+      },
+      "family_name": {
+        "type": "text"
+      },
+      "identifiers": {
+        "properties": {
+          "identifier": {
+            "type": "keyword",
+            "fields": {
+              "suggest": {
+                "type": "search_as_you_type"
+              }
+            }
+          },
+          "scheme": {
+            "type": "keyword"
+          }
+        }
+      },
+      "affiliations": {
+        "type": "object",
+        "properties": {
+          "@v": {
+            "type": "keyword"
+          },
+          "id": {
+            "type": "keyword"
+          },
+          "name": {
+            "type": "keyword",
+            "fields": {
+              "suggest": {
+                "type": "search_as_you_type"
+              }
+            }
+          }
+        }
+      },
+      "pid": {
+        "type": "object",
+        "properties": {
+          "pk": {
+            "type": "integer"
+          },
+          "pid_type": {
+            "type": "keyword"
+          },
+          "obj_type": {
+            "type": "keyword"
+          },
+          "status": {
+            "type": "keyword"
+          }
+        }
+      }
+    }
+  }
+}

--- a/invenio_vocabularies/contrib/subjects/mappings/os-v2/__init__.py
+++ b/invenio_vocabularies/contrib/subjects/mappings/os-v2/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""OpenSearch version 2 mappings."""

--- a/invenio_vocabularies/contrib/subjects/mappings/os-v2/subjects/subject-v1.0.0.json
+++ b/invenio_vocabularies/contrib/subjects/mappings/os-v2/subjects/subject-v1.0.0.json
@@ -1,0 +1,61 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "$schema": {
+        "type": "keyword",
+        "index": "false"
+      },
+      "created": {
+        "type": "date"
+      },
+      "updated": {
+        "type": "date"
+      },
+      "indexed_at": {
+        "type": "date"
+      },
+      "uuid": {
+        "type": "keyword"
+      },
+      "version_id": {
+        "type": "integer"
+      },
+      "id": {
+        "type": "keyword"
+      },
+      "scheme": {
+        "type": "keyword"
+      },
+      "subject": {
+        "type": "text",
+        "copy_to": "subject_sort",
+        "fields": {
+          "suggest": {
+            "type": "search_as_you_type"
+          }
+        }
+      },
+      "subject_sort": {
+        "type": "keyword"
+      },
+      "pid": {
+        "type": "object",
+        "properties": {
+          "pk": {
+            "type": "integer"
+          },
+          "pid_type": {
+            "type": "keyword"
+          },
+          "obj_type": {
+            "type": "keyword"
+          },
+          "status": {
+            "type": "keyword"
+          }
+        }
+      }
+    }
+  }
+}

--- a/invenio_vocabularies/records/mappings/os-v2/__init__.py
+++ b/invenio_vocabularies/records/mappings/os-v2/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""OpenSearch v2 mappings."""

--- a/invenio_vocabularies/records/mappings/os-v2/vocabularies/vocabulary-v1.0.0.json
+++ b/invenio_vocabularies/records/mappings/os-v2/vocabularies/vocabulary-v1.0.0.json
@@ -1,0 +1,90 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "$schema": {
+        "type": "keyword",
+        "index": "false"
+      },
+      "created": {
+        "type": "date"
+      },
+      "updated": {
+        "type": "date"
+      },
+      "indexed_at": {
+        "type": "date"
+      },
+      "uuid": {
+        "type": "keyword"
+      },
+      "version_id": {
+        "type": "integer"
+      },
+      "id": {
+        "type": "keyword",
+        "fields": {
+          "text": {
+            "type": "search_as_you_type"
+          }
+        }
+      },
+      "type": {
+        "type": "object",
+        "properties": {
+          "pid_type": {
+            "type": "keyword"
+          },
+          "id": {
+            "type": "keyword"
+          }
+        }
+      },
+      "pid": {
+        "type": "object",
+        "properties": {
+          "pk": {
+            "type": "integer"
+          },
+          "pid_type": {
+            "type": "keyword"
+          },
+          "obj_type": {
+            "type": "keyword"
+          },
+          "status": {
+            "type": "keyword"
+          }
+        }
+      },
+      "title_sort": {
+        "type": "keyword"
+      },
+      "title": {
+        "type": "object",
+        "dynamic": true,
+        "properties": {
+          "en": {
+            "type": "search_as_you_type",
+            "copy_to": "title_sort"
+          }
+        }
+      },
+      "description": {
+        "type": "object",
+        "dynamic": true
+      },
+      "icon": {
+        "type": "keyword",
+        "index": "false"
+      },
+      "tags": {
+        "type": "keyword"
+      },
+      "props": {
+        "type": "object",
+        "dynamic": true
+      }
+    }
+  }
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,8 @@ elasticsearch7 =
     invenio-search[elasticsearch7]>=2.0.0,<3.0.0
 opensearch1 =
     invenio-search[opensearch1]>=2.0.0,<3.0.0
+opensearch2 =
+    invenio-search[opensearch2]>=2.0.0,<3.0.0
 # Kept for backwards compatibility:
 mysql =
 postgresql =

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ packages = find:
 python_requires = >=3.7
 zip_safe = False
 install_requires =
-    invenio-records-resources>=0.21.3,<0.22.0
+    invenio-records-resources>=0.21.4,<0.22.0
     lxml>=4.5.0
     PyYAML>=5.4.1
 
@@ -36,14 +36,14 @@ tests =
     pytest-black>=0.3.0
     invenio-app>=1.3.3,<2.0.0
     invenio-db[postgresql,mysql]>=1.0.14,<2.0.0
-    pytest-invenio>=2.0.0,<3.0.0
+    pytest-invenio>=2.1.0,<3.0.0
     Sphinx>=4.5
 elasticsearch7 =
-    invenio-search[elasticsearch7]>=2.0.0,<3.0.0
+    invenio-search[elasticsearch7]>=2.1.0,<3.0.0
 opensearch1 =
-    invenio-search[opensearch1]>=2.0.0,<3.0.0
+    invenio-search[opensearch1]>=2.1.0,<3.0.0
 opensearch2 =
-    invenio-search[opensearch2]>=2.0.0,<3.0.0
+    invenio-search[opensearch2]>=2.1.0,<3.0.0
 # Kept for backwards compatibility:
 mysql =
 postgresql =

--- a/tests/contrib/affiliations/test_affiliations_api.py
+++ b/tests/contrib/affiliations/test_affiliations_api.py
@@ -21,7 +21,7 @@ from invenio_vocabularies.contrib.affiliations.api import Affiliation
 @pytest.fixture()
 def search_get():
     """Get a document from an index."""
-    return partial(current_search_client.get, Affiliation.index._name, doc_type="_doc")
+    return partial(current_search_client.get, Affiliation.index._name)
 
 
 @pytest.fixture()

--- a/tests/contrib/awards/test_awards_api.py
+++ b/tests/contrib/awards/test_awards_api.py
@@ -22,7 +22,7 @@ from invenio_vocabularies.contrib.awards.api import Award
 @pytest.fixture()
 def search_get():
     """Get a document from an index."""
-    return partial(current_search_client.get, Award.index._name, doc_type="_doc")
+    return partial(current_search_client.get, Award.index._name)
 
 
 @pytest.fixture()

--- a/tests/contrib/funders/test_funders_api.py
+++ b/tests/contrib/funders/test_funders_api.py
@@ -21,7 +21,7 @@ from invenio_vocabularies.contrib.funders.api import Funder
 @pytest.fixture()
 def search_get():
     """Get a document from an index."""
-    return partial(current_search_client.get, Funder.index._name, doc_type="_doc")
+    return partial(current_search_client.get, Funder.index._name)
 
 
 @pytest.fixture()

--- a/tests/contrib/names/test_names_api.py
+++ b/tests/contrib/names/test_names_api.py
@@ -22,7 +22,7 @@ from invenio_vocabularies.contrib.names.api import Name
 @pytest.fixture()
 def search_get():
     """Get a document from an index."""
-    return partial(current_search_client.get, Name.index._name, doc_type="_doc")
+    return partial(current_search_client.get, Name.index._name)
 
 
 @pytest.fixture()

--- a/tests/contrib/subjects/test_subjects_api.py
+++ b/tests/contrib/subjects/test_subjects_api.py
@@ -21,7 +21,7 @@ from invenio_vocabularies.contrib.subjects.api import Subject
 @pytest.fixture()
 def search_get():
     """Get a document from an index."""
-    return partial(current_search_client.get, Subject.index._name, doc_type="_doc")
+    return partial(current_search_client.get, Subject.index._name)
 
 
 @pytest.fixture()

--- a/tests/records/conftest.py
+++ b/tests/records/conftest.py
@@ -31,7 +31,7 @@ def indexer():
 @pytest.fixture()
 def search_get():
     """Get a document from an index."""
-    return partial(current_search_client.get, Vocabulary.index._name, doc_type="_doc")
+    return partial(current_search_client.get, Vocabulary.index._name)
 
 
 @pytest.fixture()

--- a/tests/records/test_relationship.py
+++ b/tests/records/test_relationship.py
@@ -37,7 +37,7 @@ def mock_indexer():
 @pytest.fixture()
 def mock_search():
     """Get a search client."""
-    return partial(current_search_client.get, Record.index._name, doc_type="_doc")
+    return partial(current_search_client.get, Record.index._name)
 
 
 #


### PR DESCRIPTION
There's still an issue going on with the suggestions for contrib vocabularies...
The following errors only happen with OSv2, but neither OSv1 nor ES7:

```
> /home/mmoser/rdm/opensearch2/invenio-vocabularies/tests/contrib/affiliations/test_affiliations_resource.py(130)test_affiliations_suggest_sort()
    128     # Should show 2 results, but id=cern as first due to acronym/name
    129     res = client.get(f"{prefix}?suggest=CERN", headers=h)
--> 130     assert res.status_code == 200
    131     assert res.json["hits"]["total"] == 2
    132     assert res.json["hits"]["hits"][0]["id"] == "cern"

ipdb> res.text
'{"status": 400, "message": "Invalid query string syntax."}'
```

Without the `?suggest=CERN` part, it works:
```
ipdb> client.get(f"{prefix}", headers=h).text
'{"hits": {"hits": [{"acronym": "CERN", "name": "CERN", "created": "2022-09-29T16:31:47.286619+00:00", "links": {"self": "https://127.0.0.1:5000/api/affiliations/cern"}, "updated": "2022-09-29T16:31:47.307105+00:00", "id": "cern", "title": {"en": "European Organization for Nuclear Research", "fr": "Conseil Europ\\u00e9en pour la Recherche Nucl\\u00e9aire"}, "revision_id": 1}, {"acronym": "CERT", "name": "CERT", "created": "2022-09-29T16:31:47.462047+00:00", "links": {"self": "https://127.0.0.1:5000/api/affiliations/cert"}, "updated": "2022-09-29T16:31:47.473284+00:00", "id": "cert", "title": {"en": "Computer Emergency Response Team", "fr": "\\u00c9quipe d\'Intervention d\'Urgence Informatique"}, "revision_id": 1}, {"acronym": "NU", "name": "Northwestern University", "created": "2022-09-29T16:31:47.506629+00:00", "links": {"self": "https://127.0.0.1:5000/api/affiliations/nu"}, "updated": "2022-09-29T16:31:47.515084+00:00", "id": "nu", "title": {"en": "Northwestern University"}, "revision_id": 1}, {"acronym": "OTHER", "name": "OTHER", "created": "2022-09-29T16:31:47.405280+00:00", "links": {"self": "https://127.0.0.1:5000/api/affiliations/other"}, "updated": "2022-09-29T16:31:47.425857+00:00", "id": "other", "title": {"en": "CERN"}, "revision_id": 1}], "total": 4}, "sortBy": "name", "links": {"self": "https://127.0.0.1:5000/api/affiliations?page=1&size=25&sort=name"}}'
```

In fact, it even works with `?suggest=` but no value:
```
ipdb> client.get(f"{prefix}?suggest=", headers=h).text
'{"hits": {"hits": [{"acronym": "CERN", "name": "CERN", "created": "2022-09-29T16:31:47.286619+00:00", "links": {"self": "https://127.0.0.1:5000/api/affiliations/cern"}, "updated": "2022-09-29T16:31:47.307105+00:00", "id": "cern", "title": {"en": "European Organization for Nuclear Research", "fr": "Conseil Europ\\u00e9en pour la Recherche Nucl\\u00e9aire"}, "revision_id": 1}, {"acronym": "CERT", "name": "CERT", "created": "2022-09-29T16:31:47.462047+00:00", "links": {"self": "https://127.0.0.1:5000/api/affiliations/cert"}, "updated": "2022-09-29T16:31:47.473284+00:00", "id": "cert", "title": {"en": "Computer Emergency Response Team", "fr": "\\u00c9quipe d\'Intervention d\'Urgence Informatique"}, "revision_id": 1}, {"acronym": "NU", "name": "Northwestern University", "created": "2022-09-29T16:31:47.506629+00:00", "links": {"self": "https://127.0.0.1:5000/api/affiliations/nu"}, "updated": "2022-09-29T16:31:47.515084+00:00", "id": "nu", "title": {"en": "Northwestern University"}, "revision_id": 1}, {"acronym": "OTHER", "name": "OTHER", "created": "2022-09-29T16:31:47.405280+00:00", "links": {"self": "https://127.0.0.1:5000/api/affiliations/other"}, "updated": "2022-09-29T16:31:47.425857+00:00", "id": "other", "title": {"en": "CERN"}, "revision_id": 1}], "total": 4}, "sortBy": "name", "links": {"self": "https://127.0.0.1:5000/api/affiliations?page=1&size=25&sort=name&suggest="}}'
```