### PR TITLE
Set `indexer_queue_name` in the service configs

### DIFF
--- a/invenio_vocabularies/services/service.py
+++ b/invenio_vocabularies/services/service.py
@@ -83,6 +83,7 @@ class VocabulariesServiceConfig(RecordServiceConfig):
     """Vocabulary service configuration."""
 
     service_id = "vocabularies"
+    indexer_queue_name = "vocabularies"
     permission_policy_cls = PermissionPolicy
     record_cls = Vocabulary
     schema = VocabularySchema


### PR DESCRIPTION
Set more specific `indexer_queue_name` for the service configs to avoid clashes with other unrelated services' indexing task queue names.

This is related to https://github.com/inveniosoftware/invenio-records-resources/pull/419.