### PR TITLE
funders: add ROR to identifiers for all funders in datastream

### DIFF
--- a/invenio_vocabularies/contrib/funders/datastreams.py
+++ b/invenio_vocabularies/contrib/funders/datastreams.py
@@ -55,7 +55,8 @@ class RORTransformer(BaseTransformer):
         for label in record.get("labels", []):
             funder["title"][label["iso639"]] = label["label"]
 
-        funder["identifiers"] = []
+        """The ROR is always listed in identifiers, expected by serialization"""
+        funder["identifiers"] = [{"identifier": funder["id"], "scheme": "ror"}]
         valid_schemes = set(funder_schemes.keys())
         fund_ref = "fundref"
         valid_schemes.add(fund_ref)

--- a/invenio_vocabularies/contrib/funders/datastreams.py
+++ b/invenio_vocabularies/contrib/funders/datastreams.py
@@ -55,7 +55,7 @@ class RORTransformer(BaseTransformer):
         for label in record.get("labels", []):
             funder["title"][label["iso639"]] = label["label"]
 
-        """The ROR is always listed in identifiers, expected by serialization"""
+        # The ROR is always listed in identifiers, expected by serialization
         funder["identifiers"] = [{"identifier": funder["id"], "scheme": "ror"}]
         valid_schemes = set(funder_schemes.keys())
         fund_ref = "fundref"

--- a/tests/contrib/funders/test_funders_datastreams.py
+++ b/tests/contrib/funders/test_funders_datastreams.py
@@ -60,6 +60,7 @@ def expected_from_ror_json():
         "title": {"en": "Funder", "de": "Geldgeber"},
         "country": "GR",
         "identifiers": [
+            {"scheme": "ror", "identifier": "0aaaaaa11"},
             {"scheme": "isni", "identifier": "0000 0001 2156 142X"},
             {"scheme": "grid", "identifier": "grid.9132.9"},
             {"scheme": "doi", "identifier": "10.13039/000000000000"},


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Adding ROR as a funder identifier when ROR is loaded through the datastream. This is the case in the demo data (https://inveniordm.web.cern.ch/api/funders), but not when funders are loaded through the datastream. When the ROR is not present in the identifiered, the DataCite serializer doesn't behave as expected https://github.com/inveniosoftware/invenio-rdm-records/issues/1038. 

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
