### PR TITLE
facets: handle non-existent vocabulary type

### DIFF
--- a/invenio_vocabularies/services/facets.py
+++ b/invenio_vocabularies/services/facets.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2021 CERN.
+# Copyright (C) 2021-2022 CERN.
 #
 # Invenio-Vocabularies is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -11,6 +11,7 @@
 from flask_principal import AnonymousIdentity
 from invenio_i18n.ext import current_i18n
 from invenio_records_resources.proxies import current_service_registry
+from invenio_records_resources.services.errors import FacetNotFoundError
 from marshmallow_utils.fields.babel import gettext_from_dict
 from speaklater import make_lazy_string
 from sqlalchemy.exc import NoResultFound
@@ -63,13 +64,11 @@ class VocabularyLabels:
                 vocabs = self.service.read_all(
                     identity, type=self.vocabulary, fields=self.fields
                 )
-            vocab_list = list(vocabs.hits)  # the service returns a generator
         except NoResultFound:
-            # in the case the vocabulary type does not exist
-            # facets should not fail but be empty
-            vocab_list = []
+            raise FacetNotFoundError(self.vocabulary)
 
         labels = {}
+        vocab_list = list(vocabs.hits)  # the service returns a generator
         ids = set(ids)
         seen = set()
         for vocab in vocab_list:


### PR DESCRIPTION
- requires https://github.com/inveniosoftware/invenio-records-resources/pull/435
- closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1952

In invenio-vocabularies we have `read`, `read_all` and `read_many`. When searching for generic vocabularies, we give two parameters vocabulary `type` and `ids` (e.g. _resourcetype_ and _publication_). In the case that publication does not exist the result would be:
- `read` --> `NoResultFound` (404) 
- `read_many` and `read_all` --> empty search result (i.e. `hits: []`)

However, all three methods assume that the vocabulary type (e.g. _resourcetype_) exists in db (we are querying `.one()` with no try/except). Then, it make the search page with a 404 because a `NoResultFound` is risen. It leads me to:
- `read` --> `NoResultFound` (404) . This is still correct, however, should we expose in the error if what does exist is the type instead of the actual id?
- `read_many` and `read_all` --> **Here is the important part**:
    - Imitating the empty search result (i.e. `hits: []`) would be the desired output for internal usage (e.g. facets). However, it is semantically incorrect, since it's not empty but rather doesn't exist.
    - 404, would need to handle this internally when labelling vocabularies <-- I'm leaning towards this solution, but would mean silent failure

