### PR TITLE
migrate to flask babel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,12 @@
 Changes
 =======
 
+Version 1.1.0 (released 2023-03-02)
+
+- serializers: deprecate marshamllow JSON
+- mappings: add dynamic template for i18n titles and descriptions
+- remove deprecated flask-babelex dependency and imports
+
 Version 1.0.4 (released 2023-01-20)
 
 - funders: Add ROR to identifiers for all funders in datastream

--- a/invenio_vocabularies/__init__.py
+++ b/invenio_vocabularies/__init__.py
@@ -10,6 +10,6 @@
 
 from .ext import InvenioVocabularies
 
-__version__ = "1.0.4"
+__version__ = "1.1.0"
 
 __all__ = ("__version__", "InvenioVocabularies")

--- a/invenio_vocabularies/config.py
+++ b/invenio_vocabularies/config.py
@@ -10,7 +10,7 @@
 """Vocabularies configuration."""
 
 import idutils
-from flask_babelex import lazy_gettext as _
+from invenio_i18n import lazy_gettext as _
 
 from .datastreams.readers import (
     CSVReader,

--- a/invenio_vocabularies/contrib/affiliations/config.py
+++ b/invenio_vocabularies/contrib/affiliations/config.py
@@ -9,7 +9,7 @@
 """Vocabulary affiliations configuration."""
 
 from flask import current_app
-from flask_babelex import lazy_gettext as _
+from invenio_i18n import lazy_gettext as _
 from invenio_records_resources.services import SearchOptions
 from invenio_records_resources.services.records.components import DataComponent
 from invenio_records_resources.services.records.params import SuggestQueryParser

--- a/invenio_vocabularies/contrib/affiliations/schema.py
+++ b/invenio_vocabularies/contrib/affiliations/schema.py
@@ -10,7 +10,7 @@
 
 from functools import partial
 
-from flask_babelex import lazy_gettext as _
+from invenio_i18n import lazy_gettext as _
 from marshmallow import fields
 from marshmallow_utils.fields import IdentifierSet, SanitizedUnicode
 from marshmallow_utils.schemas import IdentifierSchema

--- a/invenio_vocabularies/contrib/awards/config.py
+++ b/invenio_vocabularies/contrib/awards/config.py
@@ -9,7 +9,7 @@
 """Vocabulary awards configuration."""
 
 from flask import current_app
-from flask_babelex import lazy_gettext as _
+from invenio_i18n import lazy_gettext as _
 from invenio_records_resources.services import SearchOptions
 from invenio_records_resources.services.records.components import (
     DataComponent,

--- a/invenio_vocabularies/contrib/awards/datastreams.py
+++ b/invenio_vocabularies/contrib/awards/datastreams.py
@@ -8,8 +8,8 @@
 
 """Awards datastreams, transformers, writers and readers."""
 
-from flask_babelex import lazy_gettext as _
 from invenio_access.permissions import system_identity
+from invenio_i18n import lazy_gettext as _
 
 from ...datastreams.errors import TransformerError
 from ...datastreams.transformers import BaseTransformer

--- a/invenio_vocabularies/contrib/awards/schema.py
+++ b/invenio_vocabularies/contrib/awards/schema.py
@@ -11,7 +11,7 @@
 from functools import partial
 
 from attr import attr
-from flask_babelex import lazy_gettext as _
+from invenio_i18n import lazy_gettext as _
 from marshmallow import (
     Schema,
     ValidationError,

--- a/invenio_vocabularies/contrib/funders/config.py
+++ b/invenio_vocabularies/contrib/funders/config.py
@@ -9,7 +9,7 @@
 """Vocabulary funders configuration."""
 
 from flask import current_app
-from flask_babelex import lazy_gettext as _
+from invenio_i18n import lazy_gettext as _
 from invenio_records_resources.services import SearchOptions
 from invenio_records_resources.services.records.components import DataComponent
 from invenio_records_resources.services.records.params import SuggestQueryParser

--- a/invenio_vocabularies/contrib/funders/datastreams.py
+++ b/invenio_vocabularies/contrib/funders/datastreams.py
@@ -8,9 +8,9 @@
 
 """Funders datastreams, transformers, writers and readers."""
 
-from flask_babelex import lazy_gettext as _
 from idutils import normalize_ror
 from invenio_access.permissions import system_identity
+from invenio_i18n import lazy_gettext as _
 
 from ...datastreams.errors import TransformerError
 from ...datastreams.transformers import BaseTransformer

--- a/invenio_vocabularies/contrib/funders/schema.py
+++ b/invenio_vocabularies/contrib/funders/schema.py
@@ -10,7 +10,7 @@
 
 from functools import partial
 
-from flask_babelex import lazy_gettext as _
+from invenio_i18n import lazy_gettext as _
 from marshmallow import (
     ValidationError,
     fields,

--- a/invenio_vocabularies/contrib/names/config.py
+++ b/invenio_vocabularies/contrib/names/config.py
@@ -9,7 +9,7 @@
 """Vocabulary names configuration."""
 
 from flask import current_app
-from flask_babelex import lazy_gettext as _
+from invenio_i18n import lazy_gettext as _
 from invenio_records_resources.services import SearchOptions
 from invenio_records_resources.services.records.components import (
     DataComponent,

--- a/invenio_vocabularies/contrib/names/schema.py
+++ b/invenio_vocabularies/contrib/names/schema.py
@@ -10,7 +10,7 @@
 
 from functools import partial
 
-from flask_babelex import lazy_gettext as _
+from invenio_i18n import lazy_gettext as _
 from invenio_records_resources.services.records.schema import BaseRecordSchema
 from marshmallow import ValidationError, fields, post_load, validates_schema
 from marshmallow_utils.fields import IdentifierSet, SanitizedUnicode

--- a/invenio_vocabularies/contrib/subjects/config.py
+++ b/invenio_vocabularies/contrib/subjects/config.py
@@ -9,7 +9,7 @@
 
 """Subjects configuration."""
 
-from flask_babelex import lazy_gettext as _
+from invenio_i18n import lazy_gettext as _
 from invenio_records_resources.services import SearchOptions
 from invenio_records_resources.services.records.components import DataComponent
 

--- a/invenio_vocabularies/contrib/subjects/schema.py
+++ b/invenio_vocabularies/contrib/subjects/schema.py
@@ -9,7 +9,7 @@
 
 """Subjects schema."""
 
-from flask_babelex import lazy_gettext as _
+from invenio_i18n import lazy_gettext as _
 from marshmallow_utils.fields import SanitizedUnicode
 
 from ...services.schema import BaseVocabularySchema, ContribVocabularyRelationSchema

--- a/invenio_vocabularies/resources/serializer.py
+++ b/invenio_vocabularies/resources/serializer.py
@@ -11,8 +11,8 @@
 from functools import partial
 
 from flask import current_app
-from flask_babelex import get_locale
 from flask_resources import BaseListSchema, BaseObjectSchema
+from invenio_i18n import get_locale
 from marshmallow import fields
 from marshmallow_utils.fields import BabelGettextDictField
 

--- a/invenio_vocabularies/services/components.py
+++ b/invenio_vocabularies/services/components.py
@@ -8,7 +8,7 @@
 
 """Vocabulary components."""
 
-from flask_babelex import lazy_gettext as _
+from invenio_i18n import lazy_gettext as _
 from invenio_records_resources.services.records.components import ServiceComponent
 from marshmallow import ValidationError
 from sqlalchemy.orm.exc import NoResultFound

--- a/invenio_vocabularies/services/schema.py
+++ b/invenio_vocabularies/services/schema.py
@@ -8,7 +8,7 @@
 
 """Vocabulary service schema."""
 
-from flask_babelex import lazy_gettext as _
+from invenio_i18n import lazy_gettext as _
 from invenio_records_resources.services.records.schema import BaseRecordSchema
 from marshmallow import (
     Schema,

--- a/invenio_vocabularies/services/service.py
+++ b/invenio_vocabularies/services/service.py
@@ -9,9 +9,9 @@
 
 """Vocabulary service."""
 
-from flask_babelex import lazy_gettext as _
 from invenio_cache import current_cache
 from invenio_db import db
+from invenio_i18n import lazy_gettext as _
 from invenio_records_resources.services import (
     Link,
     LinksTemplate,

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -3,7 +3,7 @@
 #
 # Copyright (C) 2020 CERN.
 # Copyright (C) 2021 Northwestern University.
-# Copyright (C) 2022 Graz University of Technology.
+# Copyright (C) 2022-2023 Graz University of Technology.
 #
 # Invenio-Vocabularies is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -22,7 +22,7 @@ function cleanup {
 trap cleanup EXIT
 
 python -m check_manifest
-python -m setup extract_messages --dry-run
+python -m setup extract_messages --output-file /dev/null
 python -m sphinx.cmd.build -qnNW docs docs/_build/html
 eval "$(docker-services-cli up --db ${DB:-postgresql} --search ${ES:-opensearch} --mq ${CACHE:-redis} --env)"
 python -m pytest $@

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,8 @@ packages = find:
 python_requires = >=3.7
 zip_safe = False
 install_requires =
-    invenio-records-resources>=1.0.0,<2.0.0
+    invenio-i18n>=2.0.0,<3.0.0
+    invenio-records-resources>=1.1.0,<2.0.0
     lxml>=4.5.0
     PyYAML>=5.4.1
 

--- a/tests/contrib/awards/conftest.py
+++ b/tests/contrib/awards/conftest.py
@@ -13,7 +13,7 @@ fixtures are available.
 """
 
 import pytest
-from flask_babelex import lazy_gettext as _
+from invenio_i18n import lazy_gettext as _
 from invenio_indexer.proxies import current_indexer_registry
 from invenio_records_resources.proxies import current_service_registry
 

--- a/tests/resources/test_resources_l10n.py
+++ b/tests/resources/test_resources_l10n.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2020-2021 CERN.
+# Copyright (C) 2023 Graz University of Technology.
 #
 # Invenio-Vocabularies is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -9,6 +10,7 @@
 """Resources layer tests."""
 
 import pytest
+from flask import g
 
 from invenio_vocabularies.records.api import Vocabulary
 
@@ -91,16 +93,28 @@ def test_get(client, example_record, h, prefix, expected_da, expected_en):
     res = client.get(f"{prefix}/{id_}", headers=h)
     assert res.json == expected_en
 
+    # the used context is not reseted, every new client.get call uses the cache
+    # which is bad
+    g._flask_babel.babel_locale = None
+
     # Choose via querystring (?ln=da)
     res = client.get(f"{prefix}/{id_}?ln=da", headers=h)
     assert res.json == expected_da
+
+    g._flask_babel.babel_locale = None
+
     res = client.get(f"{prefix}/{id_}?ln=en", headers=h)
     assert res.json == expected_en
+
+    g._flask_babel.babel_locale = None
 
     # Choose via header
     h["accept-language"] = "da"
     res = client.get(f"{prefix}/{id_}", headers=h)
     assert res.json == expected_da
+
+    g._flask_babel.babel_locale = None
+
     h["accept-language"] = "en"
     res = client.get(f"{prefix}/{id_}", headers=h)
     assert res.json == expected_en
@@ -115,16 +129,26 @@ def test_search(client, example_record, h, prefix, expected_da, expected_en):
     res = client.get(f"{prefix}", headers=h)
     assert res.json == expected_en
 
+    g._flask_babel.babel_locale = None
+
     # Choose via querystring (?ln=da)
     res = client.get(f"{prefix}?ln=da", headers=h)
     assert res.json == expected_da
+
+    g._flask_babel.babel_locale = None
+
     res = client.get(f"{prefix}?ln=en", headers=h)
     assert res.json == expected_en
+
+    g._flask_babel.babel_locale = None
 
     # Choose via header
     h["accept-language"] = "da"
     res = client.get(f"{prefix}", headers=h)
     assert res.json == expected_da
+
+    g._flask_babel.babel_locale = None
+
     h["accept-language"] = "en"
     res = client.get(f"{prefix}", headers=h)
     assert res.json == expected_en


### PR DESCRIPTION
- migrate: flask_babelex replaced by invenio_i18n
- tests: fix extract_messages --dry-run
- fix: different client.get calls uses one namespace

- NOTE: invenio-i18n, invenio-accounts, invenio-theme has to be released before