### PR TITLE
Including mysql tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,12 +33,15 @@ jobs:
       matrix:
         python-version: [3.7, 3.8, 3.9]
         requirements-level: [pypi]
-        db-service: [postgresql10, postgresql13]
-        search-service: [opensearch2,elasticsearch7]
+        db-service: [postgresql10, postgresql13, mysql8]
+        search-service: [opensearch2, elasticsearch7]
         node-version: [16.x]
         exclude:
           - python-version: 3.7
             db-service: postgresql13
+
+          - python-version: 3.7
+            db-service: mysql8
 
         include:
           - search-service: opensearch2
@@ -46,6 +49,9 @@ jobs:
 
           - search-service: elasticsearch7
             SEARCH_EXTRAS: "elasticsearch7"
+
+          - db-service: mysql8
+            DB_EXTRAS: "mysql"
 
     env:
       DB: ${{ matrix.db-service }}

--- a/invenio_vocabularies/alembic/4a9a4fd235f8_create_vocabulary_schemes.py
+++ b/invenio_vocabularies/alembic/4a9a4fd235f8_create_vocabulary_schemes.py
@@ -20,10 +20,10 @@ def upgrade():
     """Upgrade database."""
     op.create_table(
         "vocabularies_schemes",
-        sa.Column("id", sa.String(), nullable=False),
-        sa.Column("parent_id", sa.String(), nullable=False),
-        sa.Column("name", sa.String(), nullable=True),
-        sa.Column("uri", sa.String(), nullable=True),
+        sa.Column("id", sa.String(255), nullable=False),
+        sa.Column("parent_id", sa.String(255), nullable=False),
+        sa.Column("name", sa.String(255), nullable=True),
+        sa.Column("uri", sa.String(255), nullable=True),
         sa.PrimaryKeyConstraint(
             "id", "parent_id", name=op.f("pk_vocabularies_schemes")
         ),

--- a/invenio_vocabularies/alembic/4f365fced43f_create_vocabularies_tables.py
+++ b/invenio_vocabularies/alembic/4f365fced43f_create_vocabularies_tables.py
@@ -78,8 +78,8 @@ def upgrade():
     )
     op.create_table(
         "vocabularies_types",
-        sa.Column("id", sa.String(), nullable=False),
-        sa.Column("pid_type", sa.String(), nullable=True),
+        sa.Column("id", sa.String(255), nullable=False),
+        sa.Column("pid_type", sa.String(255), nullable=True),
         sa.PrimaryKeyConstraint("id", name=op.f("pk_vocabularies_types")),
         sa.UniqueConstraint("pid_type", name=op.f("uq_vocabularies_types_pid_type")),
     )

--- a/invenio_vocabularies/alembic/676dd587542d_create_funders_vocabulary_table.py
+++ b/invenio_vocabularies/alembic/676dd587542d_create_funders_vocabulary_table.py
@@ -45,7 +45,7 @@ def upgrade():
             nullable=True,
         ),
         sa.Column("version_id", sa.Integer(), nullable=False),
-        sa.Column("pid", sa.String(), nullable=True),
+        sa.Column("pid", sa.String(255), nullable=True),
         sa.PrimaryKeyConstraint("id", name=op.f("pk_funder_metadata")),
         sa.UniqueConstraint("pid", name=op.f("uq_funder_metadata_pid")),
     )

--- a/invenio_vocabularies/alembic/e1146238edd3_create_awards_table.py
+++ b/invenio_vocabularies/alembic/e1146238edd3_create_awards_table.py
@@ -45,7 +45,7 @@ def upgrade():
             nullable=True,
         ),
         sa.Column("version_id", sa.Integer(), nullable=False),
-        sa.Column("pid", sa.String(), nullable=True),
+        sa.Column("pid", sa.String(255), nullable=True),
         sa.PrimaryKeyConstraint("id", name=op.f("pk_award_metadata")),
         sa.UniqueConstraint("pid", name=op.f("uq_award_metadata_pid")),
     )

--- a/invenio_vocabularies/contrib/awards/awards.py
+++ b/invenio_vocabularies/contrib/awards/awards.py
@@ -47,7 +47,7 @@ record_type = RecordTypeFactory(
     model_cls_attrs={
         # cannot set to nullable=False because it would fail at
         # service level when create({}), see records-resources.
-        "pid": db.Column(db.String, unique=True),
+        "pid": db.Column(db.String(255), unique=True),
     },
     record_dumper=SearchDumper(
         model_fields={"pid": ("id", str)},

--- a/invenio_vocabularies/contrib/funders/funders.py
+++ b/invenio_vocabularies/contrib/funders/funders.py
@@ -35,7 +35,7 @@ record_type = RecordTypeFactory(
     model_cls_attrs={
         # cannot set to nullable=False because it would fail at
         # service level when create({}), see records-resources.
-        "pid": db.Column(db.String, unique=True),
+        "pid": db.Column(db.String(255), unique=True),
     },
     record_dumper=SearchDumper(
         model_fields={"pid": ("id", str)},

--- a/invenio_vocabularies/records/models.py
+++ b/invenio_vocabularies/records/models.py
@@ -17,8 +17,8 @@ class VocabularyType(db.Model):
 
     __tablename__ = "vocabularies_types"
 
-    id = db.Column(db.String, primary_key=True)
-    pid_type = db.Column(db.String, unique=True)
+    id = db.Column(db.String(255), primary_key=True)
+    pid_type = db.Column(db.String(255), unique=True)
 
     @classmethod
     def create(cls, **data):
@@ -67,11 +67,11 @@ class VocabularyScheme(db.Model):
 
     __tablename__ = "vocabularies_schemes"
 
-    id = db.Column(db.String, primary_key=True)
+    id = db.Column(db.String(255), primary_key=True)
     # This is e.g. `subjects`, 'affiliations', ...
-    parent_id = db.Column(db.String, primary_key=True)
-    name = db.Column(db.String)
-    uri = db.Column(db.String)
+    parent_id = db.Column(db.String(255), primary_key=True)
+    name = db.Column(db.String(255))
+    uri = db.Column(db.String(255))
     # Any extra metadata is added as columns.
 
     @classmethod

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -24,7 +24,7 @@ trap cleanup EXIT
 python -m check_manifest
 python -m setup extract_messages --output-file /dev/null
 python -m sphinx.cmd.build -qnNW docs docs/_build/html
-eval "$(docker-services-cli up --db ${DB:-postgresql} --search ${ES:-opensearch} --mq ${CACHE:-redis} --env)"
+eval "$(docker-services-cli up --db ${DB:-mysql} --search ${ES:-opensearch} --mq ${CACHE:-redis} --env)"
 python -m pytest $@
 tests_exit_code=$?
 exit "$tests_exit_code"


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

This PR includes some mysql tests. This is related to https://github.com/inveniosoftware/invenio-app-rdm/issues/2232
The main issue is that `user_resources` is tested both in mysql and postgress. The mysql tests failed, since vocabularies did not define the length of the fields. 


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
