### PR TITLE
cli : Safely check writers 'args' on update

### DIFF
--- a/invenio_vocabularies/cli.py
+++ b/invenio_vocabularies/cli.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2020-2021 CERN.
 # Copyright (C) 2021 Graz University of Technology.
+# Copyright (C) 2024 KTH Royal Institute of Technology.
 #
 # Invenio-Vocabularies is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -131,7 +132,7 @@ def update(vocabulary, filepath=None, origin=None):
     config = get_config_for_ds(vocabulary, filepath, origin)
 
     for w_conf in config["writers"]:
-        w_conf["args"]["update"] = True
+        w_conf.setdefault("args", {})["update"] = True
 
     success, errored, filtered = _process_vocab(config)
 

--- a/tests/resources/test_resources_l10n.py
+++ b/tests/resources/test_resources_l10n.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2020-2021 CERN.
 # Copyright (C) 2023 Graz University of Technology.
+# Copyright (C) 2024 KTH Royal Institute of Technology.
 #
 # Invenio-Vocabularies is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -122,9 +123,22 @@ def test_get(client, example_record, h, prefix, expected_da, expected_en):
 
 def test_search(client, example_record, h, prefix, expected_da, expected_en):
     """Test search result serialization."""
-    expected_en = {"hits": {"hits": [expected_en], "total": 1}}
-    expected_da = {"hits": {"hits": [expected_da], "total": 1}}
 
+    def generate_expected_dict(expected_hits):
+        """Generate expected dict for search results."""
+        return {
+            "hits": {
+                "hits": [expected_hits],
+                "total": 1,
+            },
+            "links": {
+                "self": "https://127.0.0.1:5000/api/vocabularies/resourcetypes2?page=1&size=25&sort=title"
+            },
+            "sortBy": "title",
+        }
+
+    expected_en = generate_expected_dict(expected_en)
+    expected_da = generate_expected_dict(expected_da)
     # Default locale
     res = client.get(f"{prefix}", headers=h)
     assert res.json == expected_en


### PR DESCRIPTION
- Closes #292
- Fix failing test (unrelated to this change.)