### PR TITLE
mappings: change "dynamic" values to string

### DIFF
--- a/invenio_vocabularies/contrib/affiliations/mappings/os-v1/affiliations/affiliation-v1.0.0.json
+++ b/invenio_vocabularies/contrib/affiliations/mappings/os-v1/affiliations/affiliation-v1.0.0.json
@@ -84,7 +84,7 @@
       },
       "title": {
         "type": "object",
-        "dynamic": true
+        "dynamic": "true"
       }
     }
   }

--- a/invenio_vocabularies/contrib/affiliations/mappings/os-v2/affiliations/affiliation-v1.0.0.json
+++ b/invenio_vocabularies/contrib/affiliations/mappings/os-v2/affiliations/affiliation-v1.0.0.json
@@ -84,7 +84,7 @@
       },
       "title": {
         "type": "object",
-        "dynamic": true
+        "dynamic": "true"
       }
     }
   }

--- a/invenio_vocabularies/contrib/affiliations/mappings/v7/affiliations/affiliation-v1.0.0.json
+++ b/invenio_vocabularies/contrib/affiliations/mappings/v7/affiliations/affiliation-v1.0.0.json
@@ -84,7 +84,7 @@
       },
       "title": {
         "type": "object",
-        "dynamic": true
+        "dynamic": "true"
       }
     }
   }

--- a/invenio_vocabularies/contrib/awards/mappings/os-v1/awards/award-v1.0.0.json
+++ b/invenio_vocabularies/contrib/awards/mappings/os-v1/awards/award-v1.0.0.json
@@ -47,7 +47,7 @@
       },
       "title": {
         "type": "object",
-        "dynamic": true
+        "dynamic": "true"
       },
       "number": {
         "type": "keyword"

--- a/invenio_vocabularies/contrib/awards/mappings/os-v2/awards/award-v1.0.0.json
+++ b/invenio_vocabularies/contrib/awards/mappings/os-v2/awards/award-v1.0.0.json
@@ -47,7 +47,7 @@
       },
       "title": {
         "type": "object",
-        "dynamic": true
+        "dynamic": "true"
       },
       "number": {
         "type": "keyword"

--- a/invenio_vocabularies/contrib/awards/mappings/v7/awards/award-v1.0.0.json
+++ b/invenio_vocabularies/contrib/awards/mappings/v7/awards/award-v1.0.0.json
@@ -47,7 +47,7 @@
       },
       "title": {
         "type": "object",
-        "dynamic": true
+        "dynamic": "true"
       },
       "number": {
         "type": "keyword"

--- a/invenio_vocabularies/contrib/funders/mappings/os-v1/funders/funder-v1.0.0.json
+++ b/invenio_vocabularies/contrib/funders/mappings/os-v1/funders/funder-v1.0.0.json
@@ -62,7 +62,7 @@
       },
       "title": {
         "type": "object",
-        "dynamic": true
+        "dynamic": "true"
       }
     }
   }

--- a/invenio_vocabularies/contrib/funders/mappings/os-v2/funders/funder-v1.0.0.json
+++ b/invenio_vocabularies/contrib/funders/mappings/os-v2/funders/funder-v1.0.0.json
@@ -62,7 +62,7 @@
       },
       "title": {
         "type": "object",
-        "dynamic": true
+        "dynamic": "true"
       }
     }
   }

--- a/invenio_vocabularies/contrib/funders/mappings/v7/funders/funder-v1.0.0.json
+++ b/invenio_vocabularies/contrib/funders/mappings/v7/funders/funder-v1.0.0.json
@@ -62,7 +62,7 @@
       },
       "title": {
         "type": "object",
-        "dynamic": true
+        "dynamic": "true"
       }
     }
   }

--- a/invenio_vocabularies/records/mappings/os-v1/vocabularies/vocabulary-v1.0.0.json
+++ b/invenio_vocabularies/records/mappings/os-v1/vocabularies/vocabulary-v1.0.0.json
@@ -81,7 +81,7 @@
       },
       "title": {
         "type": "object",
-        "dynamic": true,
+        "dynamic": "true",
         "properties": {
           "en": {
             "type": "search_as_you_type",
@@ -91,7 +91,7 @@
       },
       "description": {
         "type": "object",
-        "dynamic": true
+        "dynamic": "true"
       },
       "icon": {
         "type": "keyword",
@@ -102,7 +102,7 @@
       },
       "props": {
         "type": "object",
-        "dynamic": true
+        "dynamic": "true"
       }
     }
   }

--- a/invenio_vocabularies/records/mappings/os-v2/vocabularies/vocabulary-v1.0.0.json
+++ b/invenio_vocabularies/records/mappings/os-v2/vocabularies/vocabulary-v1.0.0.json
@@ -81,7 +81,7 @@
       },
       "title": {
         "type": "object",
-        "dynamic": true,
+        "dynamic": "true",
         "properties": {
           "en": {
             "type": "search_as_you_type",
@@ -91,7 +91,7 @@
       },
       "description": {
         "type": "object",
-        "dynamic": true
+        "dynamic": "true"
       },
       "icon": {
         "type": "keyword",
@@ -102,7 +102,7 @@
       },
       "props": {
         "type": "object",
-        "dynamic": true
+        "dynamic": "true"
       }
     }
   }

--- a/invenio_vocabularies/records/mappings/v7/vocabularies/vocabulary-v1.0.0.json
+++ b/invenio_vocabularies/records/mappings/v7/vocabularies/vocabulary-v1.0.0.json
@@ -81,7 +81,7 @@
       },
       "title": {
         "type": "object",
-        "dynamic": true,
+        "dynamic": "true",
         "properties": {
           "en": {
             "type": "search_as_you_type",
@@ -91,7 +91,7 @@
       },
       "description": {
         "type": "object",
-        "dynamic": true
+        "dynamic": "true"
       },
       "icon": {
         "type": "keyword",
@@ -102,7 +102,7 @@
       },
       "props": {
         "type": "object",
-        "dynamic": true
+        "dynamic": "true"
       }
     }
   }

--- a/invenio_vocabularies/services/custom_fields/vocabulary.py
+++ b/invenio_vocabularies/services/custom_fields/vocabulary.py
@@ -58,7 +58,7 @@ class VocabularyCF(BaseCF):
             "properties": {
                 "@v": {"type": "keyword"},
                 "id": {"type": "keyword"},
-                "title": {"type": "object", "dynamic": True},
+                "title": {"type": "object", "dynamic": "true"},
             },
         }
 

--- a/tests/custom_fields/test_custom_fields.py
+++ b/tests/custom_fields/test_custom_fields.py
@@ -44,7 +44,7 @@ def test_cf_mapping(vocabulary_cf):
         "properties": {
             "@v": {"type": "keyword"},
             "id": {"type": "keyword"},
-            "title": {"type": "object", "dynamic": True},
+            "title": {"type": "object", "dynamic": "true"},
         },
     }
 

--- a/tests/mock_module/mappings/v6/records/record-v1.0.0.json
+++ b/tests/mock_module/mappings/v6/records/record-v1.0.0.json
@@ -38,7 +38,7 @@
                 },
                 "title": {
                   "type": "object",
-                  "dynamic": true
+                  "dynamic": "true"
                 }
               }
             }

--- a/tests/mock_module/mappings/v7/records/record-v1.0.0.json
+++ b/tests/mock_module/mappings/v7/records/record-v1.0.0.json
@@ -37,7 +37,7 @@
               },
               "title": {
                 "type": "object",
-                "dynamic": true
+                "dynamic": "true"
               }
             }
           }


### PR DESCRIPTION
- The mapping is stored as a string/enum in ES/OS. Using the same type makes sure the mapping comparison is correct when performing a mapping update.