### PR TITLE
Funders: fix: exclude ROR schema v2 json

### DIFF
--- a/invenio_vocabularies/contrib/awards/datastreams.py
+++ b/invenio_vocabularies/contrib/awards/datastreams.py
@@ -103,7 +103,7 @@ DATASTREAM_CONFIG = {
         {
             "type": "tar",
             "args": {
-                "regex": ".json.gz$",
+                "regex": "\\.json.gz$",
                 "mode": "r",
             },
         },

--- a/invenio_vocabularies/contrib/funders/datastreams.py
+++ b/invenio_vocabularies/contrib/funders/datastreams.py
@@ -96,7 +96,7 @@ DATASTREAM_CONFIG = {
         {
             "type": "zip",
             "args": {
-                "regex": ".json$",
+                "regex": "(?<!_schema_v2)\\.json$",
             },
         },
         {"type": "json"},

--- a/invenio_vocabularies/contrib/names/datastreams.py
+++ b/invenio_vocabularies/contrib/names/datastreams.py
@@ -109,7 +109,7 @@ DATASTREAM_CONFIG = {
         {
             "type": "tar",
             "args": {
-                "regex": ".xml$",
+                "regex": "\\.xml$",
             },
         },
         {"type": "xml"},

--- a/tests/datastreams/test_datastreams.py
+++ b/tests/datastreams/test_datastreams.py
@@ -118,7 +118,7 @@ def test_piping_readers(app, zip_file, json_element):
                 "type": "zip",
                 "args": {
                     "origin": "reader_test.zip",
-                    "regex": ".json$",
+                    "regex": "\\.json$",
                 },
             },
             {"type": "json"},


### PR DESCRIPTION
:heart: Thank you for your contribution!

Partially fixes #305 

### Description

:books: Quoting the [ROR data dump documentation](https://ror.readme.io/docs/data-dump):

> Beginning with release v1.45 on 11 April 2024, data releases contain JSON and CSV files formatted according to both schema v1 and schema v2. Version 2 files have `_schema_v2` appended to the end of the filename, e.g., `v1.45-2024-04-11-ror-data_schema_v2.json`. In order to maintain compatibility with previous release, version 1 files have no version information in the filename, e.g., `v1.45-2024-04-11-ror-data.json`.

:bomb: This breaks the funders convert script, which goes through both v1 and v2 files:

```bash
$ invenio vocabularies convert -v funders -o v1.46-2024-05-02-ror-data.zip -t affiliations_ror.yaml

[...]
RORTransformer: Name not found in ROR entry.
RORTransformer: Name not found in ROR entry.
RORTransformer: Name not found in ROR entry.
Vocabulary funders converted. Total items 218710. 
109355 items succeeded
109355 contained errors
0 were filtered.
```

:adhesive_bandage: This pull request:
* Adds a negative lookbehind assertion for `_schema_v2` before `.json`.
* Escapes the `.` in all the datastream regexes since the way it was used meant "any character".

:heavy_check_mark: The funders convert script then works as expected:

```bash
$ invenio vocabularies convert -v funders -o v1.46-2024-05-02-ror-data.zip -t affiliations_ror.yaml
Vocabulary funders converted. Total items 109355. 
109355 items succeeded
0 contained errors
0 were filtered.
```

:information_source: Remark: if and when we move to v2, the regex can easily be changed to `"regex": "_schema_v2\\.json$"`.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
