### PR TITLE
datastreams: add ROR HTTP reader and use it for funders

### DIFF
--- a/invenio_vocabularies/contrib/common/__init__.py
+++ b/invenio_vocabularies/contrib/common/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Vocabularies common module."""

--- a/invenio_vocabularies/contrib/common/ror/__init__.py
+++ b/invenio_vocabularies/contrib/common/ror/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""ROR-related module."""

--- a/invenio_vocabularies/contrib/common/ror/datastreams.py
+++ b/invenio_vocabularies/contrib/common/ror/datastreams.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""ROR-related Datastreams Readers/Writers/Transformers module."""
+
+import io
+
+import requests
+
+from invenio_vocabularies.datastreams.errors import ReaderError
+from invenio_vocabularies.datastreams.readers import BaseReader
+
+
+class RORHTTPReader(BaseReader):
+    """ROR HTTP Reader returning an in-memory binary stream of the latest ROR data dump ZIP file."""
+
+    def _iter(self, fp, *args, **kwargs):
+        raise NotImplementedError(
+            "RORHTTPReader downloads one file and therefore does not iterate through items"
+        )
+
+    def read(self, item=None, *args, **kwargs):
+        """Reads the latest ROR data dump ZIP file from Zenodo and yields an in-memory binary stream of it."""
+        if item:
+            raise NotImplementedError(
+                "RORHTTPReader does not support being chained after another reader"
+            )
+
+        # Call the signposting `linkset+json` endpoint for the Concept DOI (i.e. latest version) of the ROR data dump.
+        # See: https://github.com/inveniosoftware/rfcs/blob/master/rfcs/rdm-0071-signposting.md#provide-an-applicationlinksetjson-endpoint
+        headers = {"Accept": "application/linkset+json"}
+        api_url = "https://zenodo.org/api/records/6347574"
+        api_resp = requests.get(api_url, headers=headers)
+        api_resp.raise_for_status()
+
+        # Extract the Landing page Link Set Object located as the first (index 0) item.
+        landing_page_linkset = api_resp.json()["linkset"][0]
+
+        # Extract the URL of the only ZIP file linked to the record.
+        landing_page_zip_items = [
+            item
+            for item in landing_page_linkset["item"]
+            if item["type"] == "application/zip"
+        ]
+        if len(landing_page_zip_items) != 1:
+            raise ReaderError(
+                f"Expected 1 ZIP item but got {len(landing_page_zip_items)}"
+            )
+        file_url = landing_page_zip_items[0]["href"]
+
+        # Download the ZIP file and fully load the response bytes content in memory.
+        # The bytes content are then wrapped by a BytesIO to be file-like object (as required by `zipfile.ZipFile`).
+        # Using directly `file_resp.raw` is not possible since `zipfile.ZipFile` requires the file-like object to be seekable.
+        file_resp = requests.get(file_url)
+        file_resp.raise_for_status()
+        yield io.BytesIO(file_resp.content)
+
+
+VOCABULARIES_DATASTREAM_READERS = {
+    "ror-http": RORHTTPReader,
+}

--- a/invenio_vocabularies/datastreams/readers.py
+++ b/invenio_vocabularies/datastreams/readers.py
@@ -136,7 +136,12 @@ class ZipReader(BaseReader):
         """Opens a Zip archive or uses the given file pointer."""
         # https://docs.python.org/3/library/zipfile.html
         if item:
-            yield from self._iter(fp=item, *args, **kwargs)
+            if isinstance(item, zipfile.ZipFile):
+                yield from self._iter(fp=item, *args, **kwargs)
+            else:
+                # If the item is not already a ZipFile (e.g. if it is a BytesIO), try to create a ZipFile from the item.
+                with zipfile.ZipFile(item, **self._options) as archive:
+                    yield from self._iter(fp=archive, *args, **kwargs)
         else:
             with zipfile.ZipFile(self._origin, **self._options) as archive:
                 yield from self._iter(fp=archive, *args, **kwargs)

--- a/tests/contrib/common/ror/test_ror_datastreams.py
+++ b/tests/contrib/common/ror/test_ror_datastreams.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""ROR-related Datastreams Readers/Writers/Transformers tests."""
+
+import io
+from unittest.mock import patch
+
+import pytest
+
+from invenio_vocabularies.contrib.common.ror.datastreams import RORHTTPReader
+from invenio_vocabularies.datastreams.errors import ReaderError
+
+API_JSON_RESPONSE_CONTENT = {
+    "linkset": [
+        {
+            "anchor": "https://example.com/records/11186879",
+            "item": [
+                {
+                    "href": "https://example.com/records/11186879/files/v1.46.1-2024-05-13-ror-data.zip",
+                    "type": "application/zip",
+                }
+            ],
+        },
+        {
+            "anchor": "https://example.com/api/records/11186879",
+            "describes": [
+                {"href": "https://example.com/records/11186879", "type": "text/html"}
+            ],
+            "type": "application/dcat+xml",
+        },
+    ]
+}
+
+API_JSON_RESPONSE_CONTENT_WRONG_NUMBER_ZIP_ITEMS_ERROR = {
+    "linkset": [
+        {
+            "anchor": "https://example.com/records/11186879",
+            "item": [
+                {
+                    "href": "https://example.com/records/11186879/files/v1.46.1-2024-05-13-ror-data.zip",
+                    "type": "application/zip",
+                },
+                {
+                    "href": "https://example.com/another/file.zip",
+                    "type": "application/zip",
+                },
+            ],
+        },
+        {
+            "anchor": "https://example.com/api/records/11186879",
+            "describes": [
+                {"href": "https://example.com/records/11186879", "type": "text/html"}
+            ],
+            "type": "application/dcat+xml",
+        },
+    ]
+}
+
+DOWNLOAD_FILE_BYTES_CONTENT = b"The content of the file"
+
+
+class MockResponse:
+    content = DOWNLOAD_FILE_BYTES_CONTENT
+
+    def __init__(self, api_json_response_content):
+        self.api_json_response_content = api_json_response_content
+
+    def json(self, **kwargs):
+        return self.api_json_response_content
+
+    def raise_for_status(self):
+        pass
+
+
+@pytest.fixture(scope="function")
+def download_file_bytes_content():
+    return DOWNLOAD_FILE_BYTES_CONTENT
+
+
+@patch(
+    "requests.get",
+    side_effect=lambda url, headers=None: MockResponse(API_JSON_RESPONSE_CONTENT),
+)
+# @patch("requests.get", side_effect=lambda url, headers: MockResponse())
+def test_ror_http_reader(_, download_file_bytes_content):
+    reader = RORHTTPReader()
+    results = []
+    for entry in reader.read():
+        results.append(entry)
+
+    assert len(results) == 1
+    assert isinstance(results[0], io.BytesIO)
+    assert results[0].read() == download_file_bytes_content
+
+
+@patch(
+    "requests.get",
+    side_effect=lambda url, headers=None: MockResponse(
+        API_JSON_RESPONSE_CONTENT_WRONG_NUMBER_ZIP_ITEMS_ERROR
+    ),
+)
+def test_ror_http_reader_wrong_number_zip_items_error(_):
+    reader = RORHTTPReader()
+    with pytest.raises(ReaderError):
+        next(reader.read())
+
+
+def test_ror_http_reader_item_not_implemented():
+    reader = RORHTTPReader()
+    with pytest.raises(NotImplementedError):
+        next(reader.read("A fake item"))
+
+
+def test_ror_http_reader_iter_not_implemented():
+    reader = RORHTTPReader()
+    with pytest.raises(NotImplementedError):
+        reader._iter("A fake file pointer")

--- a/tests/datastreams/test_readers.py
+++ b/tests/datastreams/test_readers.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2021 CERN.
+# Copyright (C) 2021-2024 CERN.
 #
 # Invenio-Vocabularies is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -9,6 +9,7 @@
 """Data Streams readers tests."""
 import json
 import tarfile
+import zipfile
 from pathlib import Path
 
 import pytest
@@ -87,6 +88,27 @@ def test_zip_reader(zip_file, json_list):
     reader = ZipReader(zip_file, regex=".json$")
     total = 0
     for data in reader.read():
+        assert json.load(data) == json_list
+        total += 1
+
+    assert total == 2  # ignored the `.other` file
+
+
+def test_zip_reader_item_zipfile_instance(zip_file, json_list):
+    reader = ZipReader(regex=".json$")
+    total = 0
+    with zipfile.ZipFile(zip_file) as archive:
+        for data in reader.read(archive):
+            assert json.load(data) == json_list
+            total += 1
+
+    assert total == 2  # ignored the `.other` file
+
+
+def test_zip_reader_item_filename_not_zipfile_instance(zip_file, json_list):
+    reader = ZipReader(regex=".json$")
+    total = 0
+    for data in reader.read(zip_file):
         assert json.load(data) == json_list
         total += 1
 


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* Fixes #311
    > **Quoted description**:
    > * Automatically download the latest ROR data dump file
    > * Stream it to the next reader/transformer without relying on the file system.
* How to review this Pull Request:
    * This Pull Request is separated in **3 logical commits**, I recommended to **review them one by one**.
* The **changes can be tested** in an InvenioRDM instance by doing:
    ```bash
    $ invenio-cli shell
    $ invenio vocabularies convert -v funders -o dummy -t funders.yaml
    Vocabulary funders converted. Total items 109355. 
    109355 items succeeded
    0 contained errors
    0 were filtered.
    ```

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
