### PR TITLE
awards: datastreams: add OpenAIRE Project HTTP Reader

### DIFF
--- a/tests/contrib/awards/test_awards_datastreams.py
+++ b/tests/contrib/awards/test_awards_datastreams.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2022 CERN.
+# Copyright (C) 2022-2024 CERN.
 #
 # Invenio-Vocabularies is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -8,7 +8,9 @@
 
 """Awards datastreams tests."""
 
+import io
 from copy import deepcopy
+from unittest.mock import patch
 
 import pytest
 from invenio_access.permissions import system_identity
@@ -16,10 +18,11 @@ from invenio_access.permissions import system_identity
 from invenio_vocabularies.contrib.awards.api import Award
 from invenio_vocabularies.contrib.awards.datastreams import (
     AwardsServiceWriter,
+    OpenAIREProjectHTTPReader,
     OpenAIREProjectTransformer,
 )
 from invenio_vocabularies.datastreams import StreamEntry
-from invenio_vocabularies.datastreams.errors import WriterError
+from invenio_vocabularies.datastreams.errors import ReaderError, WriterError
 
 
 @pytest.fixture(scope="function")
@@ -110,6 +113,126 @@ def expected_from_award_json_ec():
         "acronym": "TS",
         "program": "test",
     }
+
+
+API_JSON_RESPONSE_CONTENT = {
+    "linkset": [
+        {
+            "anchor": "https://example.com/records/10488385",
+            "item": [
+                {
+                    "href": "https://example.com/records/10488385/files/organization.tar",
+                    "type": "application/x-tar",
+                },
+                {
+                    "href": "https://example.com/records/10488385/files/project.tar",
+                    "type": "application/x-tar",
+                },
+            ],
+        },
+        {
+            "anchor": "https://example.com/api/records/10488385",
+            "describes": [
+                {"href": "https://example.com/records/10488385", "type": "text/html"}
+            ],
+            "type": "application/dcat+xml",
+        },
+    ]
+}
+
+API_JSON_RESPONSE_CONTENT_WRONG_NUMBER_PROJECT_TAR_ITEMS_ERROR = {
+    "linkset": [
+        {
+            "anchor": "https://example.com/records/10488385",
+            "item": [
+                {
+                    "href": "https://example.com/records/10488385/files/organization.tar",
+                    "type": "application/x-tar",
+                },
+                {
+                    "href": "https://example.com/records/10488385/files/project.tar",
+                    "type": "application/x-tar",
+                },
+                {
+                    "href": "https://example.com/another/project.tar",
+                    "type": "application/x-tar",
+                },
+            ],
+        },
+        {
+            "anchor": "https://example.com/api/records/10488385",
+            "describes": [
+                {"href": "https://example.com/records/10488385", "type": "text/html"}
+            ],
+            "type": "application/dcat+xml",
+        },
+    ]
+}
+
+DOWNLOAD_FILE_BYTES_CONTENT = b"The content of the file"
+
+
+class MockResponse:
+    content = DOWNLOAD_FILE_BYTES_CONTENT
+
+    def __init__(self, api_json_response_content):
+        self.api_json_response_content = api_json_response_content
+
+    def json(self, **kwargs):
+        return self.api_json_response_content
+
+    def raise_for_status(self):
+        pass
+
+
+@pytest.fixture(scope="function")
+def download_file_bytes_content():
+    return DOWNLOAD_FILE_BYTES_CONTENT
+
+
+@patch(
+    "requests.get",
+    side_effect=lambda url, headers=None: MockResponse(API_JSON_RESPONSE_CONTENT),
+)
+def test_openaire_project_http_reader(_, download_file_bytes_content):
+    reader = OpenAIREProjectHTTPReader(origin="full")
+    results = []
+    for entry in reader.read():
+        results.append(entry)
+
+    assert len(results) == 1
+    assert isinstance(results[0], io.BytesIO)
+    assert results[0].read() == download_file_bytes_content
+
+
+@patch(
+    "requests.get",
+    side_effect=lambda url, headers=None: MockResponse(
+        API_JSON_RESPONSE_CONTENT_WRONG_NUMBER_PROJECT_TAR_ITEMS_ERROR
+    ),
+)
+def test_openaire_project_http_reader_wrong_number_tar_items_error(_):
+    reader = OpenAIREProjectHTTPReader(origin="full")
+    with pytest.raises(ReaderError):
+        next(reader.read())
+
+
+def test_openaire_project_http_reader_unsupported_origin_option():
+    reader = OpenAIREProjectHTTPReader(origin="unsupported_origin_option")
+    with pytest.raises(ReaderError):
+        next(reader.read())
+
+
+def test_openaire_project_http_reader_item_not_implemented():
+    reader = OpenAIREProjectHTTPReader()
+    with pytest.raises(NotImplementedError):
+        next(reader.read("A fake item"))
+
+
+def test_openaire_project_http_reader_iter_not_implemented():
+    reader = OpenAIREProjectHTTPReader()
+    with pytest.raises(NotImplementedError):
+        reader._iter("A fake file pointer")
 
 
 def test_awards_transformer(app, dict_award_entry, expected_from_award_json):

--- a/tests/contrib/common/ror/test_ror_datastreams.py
+++ b/tests/contrib/common/ror/test_ror_datastreams.py
@@ -87,7 +87,6 @@ def download_file_bytes_content():
     "requests.get",
     side_effect=lambda url, headers=None: MockResponse(API_JSON_RESPONSE_CONTENT),
 )
-# @patch("requests.get", side_effect=lambda url, headers: MockResponse())
 def test_ror_http_reader(_, download_file_bytes_content):
     reader = RORHTTPReader()
     results = []

--- a/tests/datastreams/test_readers.py
+++ b/tests/datastreams/test_readers.py
@@ -7,6 +7,7 @@
 # details.
 
 """Data Streams readers tests."""
+import io
 import json
 import tarfile
 import zipfile
@@ -80,6 +81,32 @@ def test_tar_reader(tar_file, expected_from_tar):
     for data in reader.read():
         assert yaml.safe_load(data) == expected_from_tar
         total += 1
+
+    assert total == 2  # ignored the `.other` file
+
+
+def test_tar_reader_item_tarfile_instance(tar_file, expected_from_tar):
+    reader = TarReader(regex=".yaml$")
+
+    total = 0
+    with tarfile.open(tar_file) as archive:
+        for data in reader.read(archive):
+            assert yaml.safe_load(data) == expected_from_tar
+            total += 1
+
+    assert total == 2  # ignored the `.other` file
+
+
+def test_tar_reader_item_bytesio_not_tarfile_instance(tar_file, expected_from_tar):
+    reader = TarReader(regex=".yaml$")
+
+    total = 0
+    with open(tar_file, "rb") as tar_file_stream, io.BytesIO(
+        tar_file_stream.read()
+    ) as tar_file_bytesio:
+        for data in reader.read(tar_file_bytesio):
+            assert yaml.safe_load(data) == expected_from_tar
+            total += 1
 
     assert total == 2  # ignored the `.other` file
 

--- a/tests/datastreams/test_readers.py
+++ b/tests/datastreams/test_readers.py
@@ -132,12 +132,15 @@ def test_zip_reader_item_zipfile_instance(zip_file, json_list):
     assert total == 2  # ignored the `.other` file
 
 
-def test_zip_reader_item_filename_not_zipfile_instance(zip_file, json_list):
+def test_zip_reader_item_bytesio_not_zipfile_instance(zip_file, json_list):
     reader = ZipReader(regex=".json$")
     total = 0
-    for data in reader.read(zip_file):
-        assert json.load(data) == json_list
-        total += 1
+    with open(zip_file, "rb") as zip_file_stream, io.BytesIO(
+        zip_file_stream.read()
+    ) as zip_file_bytesio:
+        for data in reader.read(zip_file_bytesio):
+            assert json.load(data) == json_list
+            total += 1
 
     assert total == 2  # ignored the `.other` file
 


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description


* Fixes #324 
    > **Quoted description**:
    > * Automatically download the latest OpenAIRE Graph dataset.
    > * Allow to choose between the full dataset or the differential one.
    > * Stream it to the next reader/transformer without relying on the file system.
* How to review this Pull Request:
    * This Pull Request is separated in **4 logical commits**, I recommended to **review them one by one**.
* The **changes can be tested** in an InvenioRDM instance by
    * Integrating the changes from
        * inveniosoftware/invenio-app-rdm#2676
        * #328
    * doing:
        ```bash
        $ invenio-cli shell
        $ invenio vocabularies convert -v awards -o diff -t awards.yaml
        # OR
        $ invenio vocabularies convert -v awards -o full -t awards.yaml
        ```

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
