### PR TITLE
Subjects to datastreams

### DIFF
--- a/invenio_vocabularies/config.py
+++ b/invenio_vocabularies/config.py
@@ -102,6 +102,11 @@ VOCABULARIES_NAMES_SCHEMES = {
 }
 """Names allowed identifier schemes."""
 
+VOCABULARIES_SUBJECTS_SCHEMES = {
+    "gnd": {"label": _("GND"), "validator": idutils.is_gnd, "datacite": "GND"},
+}
+"""Subjects allowed identifier schemes."""
+
 VOCABULARIES_DATASTREAM_READERS = {
     "csv": CSVReader,
     "json": JsonReader,

--- a/invenio_vocabularies/contrib/subjects/config.py
+++ b/invenio_vocabularies/contrib/subjects/config.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2021 CERN.
 # Copyright (C) 2021 Northwestern University.
+# Copyright (C) 2024 University of Münster.
 #
 # Invenio-Vocabularies is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more

--- a/invenio_vocabularies/contrib/subjects/config.py
+++ b/invenio_vocabularies/contrib/subjects/config.py
@@ -30,7 +30,7 @@ class SubjectsSearchOptions(SearchOptions):
     suggest_parser_cls = FilteredSuggestQueryParser.factory(
         filter_field="scheme",
         fields=[  # suggest fields
-            "subject^100",
+            "subject.*^100",
             "synonyms^20",
         ],
     )
@@ -46,7 +46,7 @@ class SubjectsSearchOptions(SearchOptions):
         ),
         "subject": dict(
             title=_("Name"),
-            fields=["subject_sort"],
+            fields=["indexed_at"],
         ),
         "newest": dict(
             title=_("Newest"),

--- a/invenio_vocabularies/contrib/subjects/config.py
+++ b/invenio_vocabularies/contrib/subjects/config.py
@@ -9,12 +9,18 @@
 
 """Subjects configuration."""
 
+from flask import current_app
 from invenio_i18n import lazy_gettext as _
 from invenio_records_resources.services import SearchOptions
 from invenio_records_resources.services.records.components import DataComponent
+from werkzeug.local import LocalProxy
 
 from ...services.components import PIDComponent
 from ...services.querystr import FilteredSuggestQueryParser
+
+subject_schemes = LocalProxy(
+    lambda: current_app.config["VOCABULARIES_SUBJECTS_SCHEMES"]
+)
 
 
 class SubjectsSearchOptions(SearchOptions):
@@ -24,8 +30,7 @@ class SubjectsSearchOptions(SearchOptions):
         filter_field="scheme",
         fields=[  # suggest fields
             "subject^100",
-            "subject._2gram",
-            "subject._3gram",
+            "synonyms^20",
         ],
     )
 

--- a/invenio_vocabularies/contrib/subjects/datastreams.py
+++ b/invenio_vocabularies/contrib/subjects/datastreams.py
@@ -45,23 +45,6 @@ class YAMLTransformer(BaseTransformer):
         for synonym in record["synonyms"]:
             subject["synonyms"].append(synonym)
 
-        if self.vocab_schemes:
-            valid_schemes = set(self.vocab_schemes.keys())
-        else:
-            valid_schemes = set()
-        subject["identifiers"] = []
-        for identifier in record["identifiers"]:
-            schemes = idutils.detect_identifier_schemes(identifier)
-            for scheme in schemes:
-                if scheme in valid_schemes:
-                    subject["identifiers"].append(
-                        {
-                            "identifier": identifier,
-                            "scheme": scheme,
-                        }
-                    )
-                    break
-
         return subject
 
 

--- a/invenio_vocabularies/contrib/subjects/datastreams.py
+++ b/invenio_vocabularies/contrib/subjects/datastreams.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021-2022 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Names datastreams, transformers, writers and readers."""
+
+from invenio_access.permissions import system_identity
+from invenio_records.dictutils import dict_lookup
+
+from ...datastreams.errors import TransformerError
+from ...datastreams.readers import SimpleHTTPReader, BaseReader
+from ...datastreams.transformers import BaseTransformer
+from ...datastreams.writers import ServiceWriter
+
+
+class SubjectsYAMLReader(BaseReader):
+    """Subjects YAML Reader."""
+
+    def __init__(self, *args, options=None, **kwargs):
+        """Constructor."""
+        self._options = options or {}
+        super().__init__(*args, **kwargs)
+
+    def _iter(self, data, *args, **kwargs):
+        """Iterates over a dictionary and returns a dictionary per element."""
+        for entry in data:
+            yield entry
+
+    def read(self, item=None, *args, **kwargs):
+        """Read the YAML file."""
+        import yaml
+
+        with open(self._options["filename"], "r") as f:
+            data = yaml.safe_load(f)
+            yield from self._iter(data=data, *args, **kwargs)
+
+
+class OAIPMHSubjectsReader(BaseReader):
+    # not implemented
+    pass
+
+
+class SubjectsYAMLTransformer(BaseTransformer):
+    """Subjects Transformer."""
+
+    def apply(self, stream_entry, **kwargs):
+        """Transform the data to the invenio subjects format."""
+        record = stream_entry.entry
+        subject_entry = {}
+        print("Transforming data to invenio subjects format...")
+
+        subject_entry["subject"] = record.get("subject")
+        subject_entry["identifier"] = record.get("identifier")
+        subject_entry["scheme"] = record.get("scheme")
+        subject_entry["parent"] = record.get("parent")
+
+        return subject_entry
+
+
+class SubjectsServiceWriter(ServiceWriter):
+    """Subjects Service Writer."""
+
+    def __init__(self, *args, **kwargs):
+        """Constructor."""
+        super().__init__(*args, **kwargs)
+
+    def write(self, data, *args, **kwargs):
+        """Write the data to the service."""
+
+
+VOCABULARIES_DATASTREAM_TRANSFORMERS = {
+    "yaml-vocabulary": SubjectsYAMLTransformer,
+}
+"""ROR Data Streams transformers."""
+
+
+VOCABULARIES_DATASTREAM_WRITERS = {
+    "subjects-service": SubjectsServiceWriter,
+}
+"""Funders Data Streams transformers."""
+
+
+DATASTREAM_CONFIG = {
+    "readers": [
+        {"type": "yaml"},
+    ],
+    "transformers": [
+        {"type": "yaml-vocabulary"},
+    ],
+    "writers": [
+        {
+            "type": "subjects-service",
+            "args": {
+                "identity": system_identity,
+            },
+        }
+    ],
+}
+"""Data Stream configuration.
+
+"""

--- a/invenio_vocabularies/contrib/subjects/datastreams.py
+++ b/invenio_vocabularies/contrib/subjects/datastreams.py
@@ -8,28 +8,62 @@
 
 """Names datastreams, transformers, writers and readers."""
 
+import idutils
 from invenio_access.permissions import system_identity
+from invenio_i18n import lazy_gettext as _
 from invenio_records.dictutils import dict_lookup
 
 from ...datastreams.errors import TransformerError
-from ...datastreams.readers import SimpleHTTPReader, BaseReader
+from ...datastreams.readers import BaseReader, SimpleHTTPReader
 from ...datastreams.transformers import BaseTransformer
 from ...datastreams.writers import ServiceWriter
+from .config import subject_schemes
 
 
-class SubjectsYAMLTransformer(BaseTransformer):
-    """Subjects Transformer."""
+class YAMLTransformer(BaseTransformer):
+    """Transforms a YAML record into a subjects record."""
+
+    def __init__(self, *args, vocab_schemes=None, **kwargs):
+        """Initializes the transformer."""
+        self.vocab_schemes = vocab_schemes
+        super().__init__(*args, **kwargs)
 
     def apply(self, stream_entry, **kwargs):
         """Transform the data to the invenio subjects format."""
         record = stream_entry.entry
-        subject_entry = {}
+        subject = {}
+        subject["subject"] = {}
 
-        subject_entry["subject"] = record.get("subject")
-        subject_entry["id"] = record.get("id")
-        subject_entry["scheme"] = record.get("scheme")
+        subject["id"] = record["id"]
+        if not subject["id"]:
+            raise TransformerError(_("Id not found in YAML entry."))
 
-        return subject_entry
+        subject["scheme"] = record["scheme"]
+        for lang in record["subject"].keys():
+            subject["subject"][lang] = record["subject"][lang]
+
+        subject["synonyms"] = []
+        for synonym in record["synonyms"]:
+            subject["synonyms"].append(synonym)
+
+        if self.vocab_schemes:
+            valid_schemes = set(self.vocab_schemes.keys())
+        else:
+            valid_schemes = set()
+        subject["identifiers"] = []
+        for identifier in record["identifiers"]:
+            schemes = idutils.detect_identifier_schemes(identifier)
+            for scheme in schemes:
+                if scheme in valid_schemes:
+                    subject["identifiers"].append(
+                        {
+                            "identifier": identifier,
+                            "scheme": scheme,
+                        }
+                    )
+                    break
+
+        return subject
 
 
 class SubjectsServiceWriter(ServiceWriter):
@@ -37,24 +71,24 @@ class SubjectsServiceWriter(ServiceWriter):
 
     def __init__(self, *args, **kwargs):
         """Constructor."""
+        service_or_name = kwargs.pop("service_or_name", "subjects")
         super().__init__(*args, **kwargs)
 
-    def write(self, data, *args, **kwargs):
-        """Write the data to the service."""
-
-        raise NotImplementedError("Not implemented yet.")
+    def _entry_id(self, entry):
+        """Get the id from an entry."""
+        return entry["id"]
 
 
 VOCABULARIES_DATASTREAM_TRANSFORMERS = {
-    "yaml-vocabulary": SubjectsYAMLTransformer,
+    "yaml-vocabulary": YAMLTransformer,
 }
-"""ROR Data Streams transformers."""
+"""Yaml Data Streams transformers."""
 
 
 VOCABULARIES_DATASTREAM_WRITERS = {
     "subjects-service": SubjectsServiceWriter,
 }
-"""Funders Data Streams transformers."""
+"""Subjects Data Streams transformers."""
 
 
 DATASTREAM_CONFIG = {
@@ -62,7 +96,12 @@ DATASTREAM_CONFIG = {
         {"type": "yaml"},
     ],
     "transformers": [
-        {"type": "yaml-vocabulary"},
+        {
+            "type": "yaml-vocabulary",
+            "args": {
+                "vocab_schemes": subject_schemes,
+            },
+        },
     ],
     "writers": [
         {
@@ -73,6 +112,4 @@ DATASTREAM_CONFIG = {
         }
     ],
 }
-"""Data Stream configuration.
-
-"""
+"""Data Stream configuration."""

--- a/invenio_vocabularies/contrib/subjects/datastreams.py
+++ b/invenio_vocabularies/contrib/subjects/datastreams.py
@@ -18,7 +18,10 @@ from ...datastreams.writers import ServiceWriter
 
 
 class SubjectsYAMLReader(BaseReader):
-    """Subjects YAML Reader."""
+    """Subjects YAML Reader.
+
+    This is needed for backwards compatibility with the old way of reading data.
+    """
 
     def __init__(self, *args, options=None, **kwargs):
         """Constructor."""
@@ -36,12 +39,8 @@ class SubjectsYAMLReader(BaseReader):
 
         with open(self._options["filename"], "r") as f:
             data = yaml.safe_load(f)
-            yield from self._iter(data=data, *args, **kwargs)
-
-
-class OAIPMHSubjectsReader(BaseReader):
-    # not implemented
-    pass
+            for entry in self._iter(data=data, *args, **kwargs):
+                yield entry
 
 
 class SubjectsYAMLTransformer(BaseTransformer):
@@ -51,12 +50,10 @@ class SubjectsYAMLTransformer(BaseTransformer):
         """Transform the data to the invenio subjects format."""
         record = stream_entry.entry
         subject_entry = {}
-        print("Transforming data to invenio subjects format...")
 
         subject_entry["subject"] = record.get("subject")
-        subject_entry["identifier"] = record.get("identifier")
+        subject_entry["id"] = record.get("id")
         subject_entry["scheme"] = record.get("scheme")
-        subject_entry["parent"] = record.get("parent")
 
         return subject_entry
 
@@ -70,6 +67,8 @@ class SubjectsServiceWriter(ServiceWriter):
 
     def write(self, data, *args, **kwargs):
         """Write the data to the service."""
+
+        raise NotImplementedError("Not implemented yet.")
 
 
 VOCABULARIES_DATASTREAM_TRANSFORMERS = {

--- a/invenio_vocabularies/contrib/subjects/datastreams.py
+++ b/invenio_vocabularies/contrib/subjects/datastreams.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2021-2022 CERN.
+# Copyright (C) 2024 University of Münster.
 #
 # Invenio-Vocabularies is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -88,7 +89,7 @@ VOCABULARIES_DATASTREAM_TRANSFORMERS = {
 VOCABULARIES_DATASTREAM_WRITERS = {
     "subjects-service": SubjectsServiceWriter,
 }
-"""Subjects Data Streams transformers."""
+"""Subjects Data Streams writers."""
 
 
 DATASTREAM_CONFIG = {

--- a/invenio_vocabularies/contrib/subjects/datastreams.py
+++ b/invenio_vocabularies/contrib/subjects/datastreams.py
@@ -54,7 +54,7 @@ class SubjectsServiceWriter(ServiceWriter):
     def __init__(self, *args, **kwargs):
         """Constructor."""
         service_or_name = kwargs.pop("service_or_name", "subjects")
-        super().__init__(*args, **kwargs)
+        super().__init__(service_or_name=service_or_name, *args, **kwargs)
 
     def _entry_id(self, entry):
         """Get the id from an entry."""

--- a/invenio_vocabularies/contrib/subjects/datastreams.py
+++ b/invenio_vocabularies/contrib/subjects/datastreams.py
@@ -12,10 +12,8 @@
 import idutils
 from invenio_access.permissions import system_identity
 from invenio_i18n import lazy_gettext as _
-from invenio_records.dictutils import dict_lookup
 
 from ...datastreams.errors import TransformerError
-from ...datastreams.readers import BaseReader, SimpleHTTPReader
 from ...datastreams.transformers import BaseTransformer
 from ...datastreams.writers import ServiceWriter
 from .config import subject_schemes

--- a/invenio_vocabularies/contrib/subjects/datastreams.py
+++ b/invenio_vocabularies/contrib/subjects/datastreams.py
@@ -17,32 +17,6 @@ from ...datastreams.transformers import BaseTransformer
 from ...datastreams.writers import ServiceWriter
 
 
-class SubjectsYAMLReader(BaseReader):
-    """Subjects YAML Reader.
-
-    This is needed for backwards compatibility with the old way of reading data.
-    """
-
-    def __init__(self, *args, options=None, **kwargs):
-        """Constructor."""
-        self._options = options or {}
-        super().__init__(*args, **kwargs)
-
-    def _iter(self, data, *args, **kwargs):
-        """Iterates over a dictionary and returns a dictionary per element."""
-        for entry in data:
-            yield entry
-
-    def read(self, item=None, *args, **kwargs):
-        """Read the YAML file."""
-        import yaml
-
-        with open(self._options["filename"], "r") as f:
-            data = yaml.safe_load(f)
-            for entry in self._iter(data=data, *args, **kwargs):
-                yield entry
-
-
 class SubjectsYAMLTransformer(BaseTransformer):
     """Subjects Transformer."""
 

--- a/invenio_vocabularies/contrib/subjects/jsonschemas/subjects/subject-v1.0.0.json
+++ b/invenio_vocabularies/contrib/subjects/jsonschemas/subjects/subject-v1.0.0.json
@@ -20,8 +20,22 @@
       "$ref": "local://definitions-v1.0.0.json#/identifier"
     },
     "subject": {
-      "description": "Human readable label.",
-      "type": "string"
+      "description": "Human readable label in different languages.",
+      "$ref": "local://vocabularies/definitions-v1.0.0.json#/title"
+    },
+    "synonyms": {
+      "description": "Synonyms of the subject label.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
+    },
+    "identifiers": {
+      "description": "Alternate (schemed) identifiers for the record.",
+      "type": "array",
+      "items": {"$ref": "local://definitions-v1.0.0.json#/identifiers_with_scheme"},
+      "uniqueItems": true
     }
   }
 }

--- a/invenio_vocabularies/contrib/subjects/jsonschemas/subjects/subject-v1.0.0.json
+++ b/invenio_vocabularies/contrib/subjects/jsonschemas/subjects/subject-v1.0.0.json
@@ -33,12 +33,6 @@
         "type": "string"
       },
       "uniqueItems": true
-    },
-    "identifiers": {
-      "description": "Alternate (schemed) identifiers for the record.",
-      "type": "array",
-      "items": {"$ref": "local://definitions-v1.0.0.json#/identifiers_with_scheme"},
-      "uniqueItems": true
     }
   }
 }

--- a/invenio_vocabularies/contrib/subjects/mappings/os-v1/subjects/subject-v1.0.0.json
+++ b/invenio_vocabularies/contrib/subjects/mappings/os-v1/subjects/subject-v1.0.0.json
@@ -59,16 +59,6 @@
           }
         }
       },
-      "identifiers": {
-        "properties": {
-          "identifier": {
-            "type": "keyword"
-          },
-          "scheme": {
-            "type": "keyword"
-          }
-        }
-      },
       "synonyms": {
         "type": "text"
       },

--- a/invenio_vocabularies/contrib/subjects/mappings/os-v1/subjects/subject-v1.0.0.json
+++ b/invenio_vocabularies/contrib/subjects/mappings/os-v1/subjects/subject-v1.0.0.json
@@ -4,7 +4,7 @@
       {
         "i18n_subject": {
           "path_match": "subject.*",
-          "match_mapping_type": "text",
+          "match_mapping_type": "string",
           "mapping": {
             "type": "search_as_you_type"
           }
@@ -70,7 +70,7 @@
         }
       },
       "synonyms": {
-        "type": "array"
+        "type": "text"
       },
       "tags": {
         "type": "keyword"

--- a/invenio_vocabularies/contrib/subjects/mappings/os-v1/subjects/subject-v1.0.0.json
+++ b/invenio_vocabularies/contrib/subjects/mappings/os-v1/subjects/subject-v1.0.0.json
@@ -71,6 +71,7 @@
       },
       "synonyms": {
         "type": "array"
+      },
       "tags": {
         "type": "keyword"
       }

--- a/invenio_vocabularies/contrib/subjects/mappings/os-v1/subjects/subject-v1.0.0.json
+++ b/invenio_vocabularies/contrib/subjects/mappings/os-v1/subjects/subject-v1.0.0.json
@@ -70,7 +70,7 @@
         }
       },
       "synonyms": {
-        "type": "text"
+        "type": "array"
       }
     }
   }

--- a/invenio_vocabularies/contrib/subjects/mappings/os-v1/subjects/subject-v1.0.0.json
+++ b/invenio_vocabularies/contrib/subjects/mappings/os-v1/subjects/subject-v1.0.0.json
@@ -1,5 +1,16 @@
 {
   "mappings": {
+    "dynamic_templates": [
+      {
+        "i18n_subject": {
+          "path_match": "subject.*",
+          "match_mapping_type": "text",
+          "mapping": {
+            "type": "search_as_you_type"
+          }
+        }
+      }
+    ],
     "dynamic": "strict",
     "properties": {
       "$schema": {
@@ -28,16 +39,8 @@
         "type": "keyword"
       },
       "subject": {
-        "type": "text",
-        "copy_to": "subject_sort",
-        "fields": {
-          "suggest": {
-            "type": "search_as_you_type"
-          }
-        }
-      },
-      "subject_sort": {
-        "type": "keyword"
+        "type": "object",
+        "dynamic": "true"
       },
       "pid": {
         "type": "object",
@@ -55,6 +58,19 @@
             "type": "keyword"
           }
         }
+      },
+      "identifiers": {
+        "properties": {
+          "identifier": {
+            "type": "keyword"
+          },
+          "scheme": {
+            "type": "keyword"
+          }
+        }
+      },
+      "synonyms": {
+        "type": "text"
       }
     }
   }

--- a/invenio_vocabularies/contrib/subjects/mappings/os-v2/subjects/subject-v1.0.0.json
+++ b/invenio_vocabularies/contrib/subjects/mappings/os-v2/subjects/subject-v1.0.0.json
@@ -59,16 +59,6 @@
           }
         }
       },
-      "identifiers": {
-        "properties": {
-          "identifier": {
-            "type": "keyword"
-          },
-          "scheme": {
-            "type": "keyword"
-          }
-        }
-      },
       "synonyms": {
         "type": "text"
       },

--- a/invenio_vocabularies/contrib/subjects/mappings/os-v2/subjects/subject-v1.0.0.json
+++ b/invenio_vocabularies/contrib/subjects/mappings/os-v2/subjects/subject-v1.0.0.json
@@ -4,7 +4,7 @@
       {
         "i18n_subject": {
           "path_match": "subject.*",
-          "match_mapping_type": "text",
+          "match_mapping_type": "string",
           "mapping": {
             "type": "search_as_you_type"
           }
@@ -70,7 +70,7 @@
         }
       },
       "synonyms": {
-        "type": "array"
+        "type": "text"
       },
       "tags": {
         "type": "keyword"

--- a/invenio_vocabularies/contrib/subjects/mappings/os-v2/subjects/subject-v1.0.0.json
+++ b/invenio_vocabularies/contrib/subjects/mappings/os-v2/subjects/subject-v1.0.0.json
@@ -71,6 +71,7 @@
       },
       "synonyms": {
         "type": "array"
+      },
       "tags": {
         "type": "keyword"
       }

--- a/invenio_vocabularies/contrib/subjects/mappings/os-v2/subjects/subject-v1.0.0.json
+++ b/invenio_vocabularies/contrib/subjects/mappings/os-v2/subjects/subject-v1.0.0.json
@@ -70,7 +70,7 @@
         }
       },
       "synonyms": {
-        "type": "text"
+        "type": "array"
       }
     }
   }

--- a/invenio_vocabularies/contrib/subjects/mappings/os-v2/subjects/subject-v1.0.0.json
+++ b/invenio_vocabularies/contrib/subjects/mappings/os-v2/subjects/subject-v1.0.0.json
@@ -1,5 +1,16 @@
 {
   "mappings": {
+    "dynamic_templates": [
+      {
+        "i18n_subject": {
+          "path_match": "subject.*",
+          "match_mapping_type": "text",
+          "mapping": {
+            "type": "search_as_you_type"
+          }
+        }
+      }
+    ],
     "dynamic": "strict",
     "properties": {
       "$schema": {
@@ -28,16 +39,8 @@
         "type": "keyword"
       },
       "subject": {
-        "type": "text",
-        "copy_to": "subject_sort",
-        "fields": {
-          "suggest": {
-            "type": "search_as_you_type"
-          }
-        }
-      },
-      "subject_sort": {
-        "type": "keyword"
+        "type": "object",
+        "dynamic": "true"
       },
       "pid": {
         "type": "object",
@@ -55,6 +58,19 @@
             "type": "keyword"
           }
         }
+      },
+      "identifiers": {
+        "properties": {
+          "identifier": {
+            "type": "keyword"
+          },
+          "scheme": {
+            "type": "keyword"
+          }
+        }
+      },
+      "synonyms": {
+        "type": "text"
       }
     }
   }

--- a/invenio_vocabularies/contrib/subjects/mappings/v7/subjects/subject-v1.0.0.json
+++ b/invenio_vocabularies/contrib/subjects/mappings/v7/subjects/subject-v1.0.0.json
@@ -70,7 +70,8 @@
         }
       },
       "synonyms": {
-        "type": "text"
+        "type": "array"
+      },
       "tags": {
         "type": "keyword"
       }

--- a/invenio_vocabularies/contrib/subjects/mappings/v7/subjects/subject-v1.0.0.json
+++ b/invenio_vocabularies/contrib/subjects/mappings/v7/subjects/subject-v1.0.0.json
@@ -59,16 +59,6 @@
           }
         }
       },
-      "identifiers": {
-        "properties": {
-          "identifier": {
-            "type": "keyword"
-          },
-          "scheme": {
-            "type": "keyword"
-          }
-        }
-      },
       "synonyms": {
         "type": "text"
       },

--- a/invenio_vocabularies/contrib/subjects/mappings/v7/subjects/subject-v1.0.0.json
+++ b/invenio_vocabularies/contrib/subjects/mappings/v7/subjects/subject-v1.0.0.json
@@ -4,7 +4,7 @@
       {
         "i18n_subject": {
           "path_match": "subject.*",
-          "match_mapping_type": "text",
+          "match_mapping_type": "string",
           "mapping": {
             "type": "search_as_you_type"
           }
@@ -70,7 +70,7 @@
         }
       },
       "synonyms": {
-        "type": "array"
+        "type": "text"
       },
       "tags": {
         "type": "keyword"

--- a/invenio_vocabularies/contrib/subjects/mappings/v7/subjects/subject-v1.0.0.json
+++ b/invenio_vocabularies/contrib/subjects/mappings/v7/subjects/subject-v1.0.0.json
@@ -1,5 +1,16 @@
 {
   "mappings": {
+    "dynamic_templates": [
+      {
+        "i18n_subject": {
+          "path_match": "subject.*",
+          "match_mapping_type": "text",
+          "mapping": {
+            "type": "search_as_you_type"
+          }
+        }
+      }
+    ],
     "dynamic": "strict",
     "properties": {
       "$schema": {
@@ -28,16 +39,8 @@
         "type": "keyword"
       },
       "subject": {
-        "type": "text",
-        "copy_to": "subject_sort",
-        "fields": {
-          "suggest": {
-            "type": "search_as_you_type"
-          }
-        }
-      },
-      "subject_sort": {
-        "type": "keyword"
+        "type": "object",
+        "dynamic": "true"
       },
       "pid": {
         "type": "object",
@@ -55,6 +58,19 @@
             "type": "keyword"
           }
         }
+      },
+      "identifiers": {
+        "properties": {
+          "identifier": {
+            "type": "keyword"
+          },
+          "scheme": {
+            "type": "keyword"
+          }
+        }
+      },
+      "synonyms": {
+        "type": "text"
       }
     }
   }

--- a/invenio_vocabularies/contrib/subjects/schema.py
+++ b/invenio_vocabularies/contrib/subjects/schema.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2021 Northwestern University.
 # Copyright (C) 2021-2022 CERN.
+# Copyright (C) 2024 University of Münster.
 #
 # Invenio-Vocabularies is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -9,10 +10,19 @@
 
 """Subjects schema."""
 
-from invenio_i18n import lazy_gettext as _
-from marshmallow_utils.fields import SanitizedUnicode
+from functools import partial
 
-from ...services.schema import BaseVocabularySchema, ContribVocabularyRelationSchema
+from invenio_i18n import lazy_gettext as _
+from marshmallow import fields
+from marshmallow_utils.fields import IdentifierSet, SanitizedUnicode
+from marshmallow_utils.schemas import IdentifierSchema
+
+from ...services.schema import (
+    BaseVocabularySchema,
+    ContribVocabularyRelationSchema,
+    i18n_strings,
+)
+from .config import subject_schemes
 
 
 class SubjectSchema(BaseVocabularySchema):
@@ -23,7 +33,17 @@ class SubjectSchema(BaseVocabularySchema):
     # here.
     id = SanitizedUnicode(required=True)
     scheme = SanitizedUnicode(required=True)
-    subject = SanitizedUnicode(required=True)
+    subject = i18n_strings
+    synonyms = fields.List(SanitizedUnicode())
+    identifiers = IdentifierSet(
+        fields.Nested(
+            partial(
+                IdentifierSchema,
+                allowed_schemes=subject_schemes,
+                identifier_required=False,
+            )
+        )
+    )
 
 
 class SubjectRelationSchema(ContribVocabularyRelationSchema):
@@ -31,5 +51,15 @@ class SubjectRelationSchema(ContribVocabularyRelationSchema):
 
     ftf_name = "subject"
     parent_field_name = "subjects"
-    subject = SanitizedUnicode()
+    subject = i18n_strings
     scheme = SanitizedUnicode()
+    synonyms = fields.List(SanitizedUnicode())
+    identifiers = IdentifierSet(
+        fields.Nested(
+            partial(
+                IdentifierSchema,
+                allowed_schemes=subject_schemes,
+                identifier_required=False,
+            )
+        )
+    )

--- a/invenio_vocabularies/factories.py
+++ b/invenio_vocabularies/factories.py
@@ -15,6 +15,7 @@ from invenio_records_resources.proxies import current_service_registry
 from .contrib.awards.datastreams import DATASTREAM_CONFIG as awards_ds_config
 from .contrib.funders.datastreams import DATASTREAM_CONFIG as funders_ds_config
 from .contrib.names.datastreams import DATASTREAM_CONFIG as names_ds_config
+from .contrib.subjects.datastreams import DATASTREAM_CONFIG as subjects_ds_config
 
 
 class VocabularyConfig:
@@ -57,6 +58,17 @@ class FundersVocabularyConfig(VocabularyConfig):
         raise NotImplementedError("Service not implemented for Funders")
 
 
+class SubjectsVocabularyConfig(VocabularyConfig):
+    """Subjects Vocabulary Config."""
+
+    config = subjects_ds_config
+    vocabulary_name = "subjects"
+
+    def get_service(self):
+        """Get the service for the vocabulary."""
+        raise NotImplementedError("Service not implemented for Subjects")
+
+
 class AwardsVocabularyConfig(VocabularyConfig):
     """Awards Vocabulary Config."""
 
@@ -74,5 +86,6 @@ def get_vocabulary_config(vocabulary):
         "names": NamesVocabularyConfig,
         "funders": FundersVocabularyConfig,
         "awards": AwardsVocabularyConfig,
+        "subjects": SubjectsVocabularyConfig,
     }
     return vocab_config.get(vocabulary, VocabularyConfig)()

--- a/invenio_vocabularies/services/service.py
+++ b/invenio_vocabularies/services/service.py
@@ -44,138 +44,138 @@ def is_custom_vocabulary_type(vocabulary_type, context):
     )
 
 
-class VocabularyMetadataList(ServiceListResult):
-    """Ensures that vocabulary metadata is returned in the proper format."""
+# class VocabularyMetadataList(ServiceListResult):
+#     """Ensures that vocabulary metadata is returned in the proper format."""
 
-    def __init__(
-        self,
-        service,
-        identity,
-        results,
-        links_tpl=None,
-        links_item_tpl=None,
-    ):
-        """Constructor.
+#     def __init__(
+#         self,
+#         service,
+#         identity,
+#         results,
+#         links_tpl=None,
+#         links_item_tpl=None,
+#     ):
+#         """Constructor.
 
-        :params service: a service instance
-        :params identity: an identity that performed the service request
-        :params results: the search results
-        """
-        self._identity = identity
-        self._results = results
-        self._service = service
-        self._links_tpl = links_tpl
-        self._links_item_tpl = links_item_tpl
+#         :params service: a service instance
+#         :params identity: an identity that performed the service request
+#         :params results: the search results
+#         """
+#         self._identity = identity
+#         self._results = results
+#         self._service = service
+#         self._links_tpl = links_tpl
+#         self._links_item_tpl = links_item_tpl
 
-    def to_dict(self):
-        """Formats result to a dict of hits."""
-        hits = list(self._results)
+#     def to_dict(self):
+#         """Formats result to a dict of hits."""
+#         hits = list(self._results)
 
-        for hit in hits:
-            if self._links_item_tpl:
-                hit["links"] = self._links_item_tpl.expand(self._identity, hit)
+#         for hit in hits:
+#             if self._links_item_tpl:
+#                 hit["links"] = self._links_item_tpl.expand(self._identity, hit)
 
-        res = {
-            "hits": {
-                "hits": hits,
-                "total": len(hits),
-            }
-        }
+#         res = {
+#             "hits": {
+#                 "hits": hits,
+#                 "total": len(hits),
+#             }
+#         }
 
-        if self._links_tpl:
-            res["links"] = self._links_tpl.expand(self._identity, None)
+#         if self._links_tpl:
+#             res["links"] = self._links_tpl.expand(self._identity, None)
 
-        return res
+#         return res
 
 
-class VocabularyTypeService(Service):
-    """Vocabulary type service."""
+# class VocabularyTypeService(Service):
+#     """Vocabulary type service."""
 
-    @property
-    def schema(self):
-        """Returns the data schema instance."""
-        return ServiceSchemaWrapper(self, schema=self.config.schema)
+#     @property
+#     def schema(self):
+#         """Returns the data schema instance."""
+#         return ServiceSchemaWrapper(self, schema=self.config.schema)
 
-    @property
-    def links_item_tpl(self):
-        """Item links template."""
-        return LinksTemplate(
-            self.config.vocabularies_listing_item,
-        )
+#     @property
+#     def links_item_tpl(self):
+#         """Item links template."""
+#         return LinksTemplate(
+#             self.config.vocabularies_listing_item,
+#         )
 
-    @property
-    def custom_vocabulary_names(self):
-        """Checks whether vocabulary is a custom vocabulary."""
-        return current_app.config.get("VOCABULARIES_CUSTOM_VOCABULARY_TYPES", [])
+#     @property
+#     def custom_vocabulary_names(self):
+#         """Checks whether vocabulary is a custom vocabulary."""
+#         return current_app.config.get("VOCABULARIES_CUSTOM_VOCABULARY_TYPES", [])
 
-    def search(self, identity):
-        """Search for vocabulary types entries."""
-        self.require_permission(identity, "list_vocabularies")
+#     def search(self, identity):
+#         """Search for vocabulary types entries."""
+#         self.require_permission(identity, "list_vocabularies")
 
-        vocabulary_types = VocabularyType.query.all()
+#         vocabulary_types = VocabularyType.query.all()
 
-        config_vocab_types = current_app.config.get(
-            "INVENIO_VOCABULARY_TYPE_METADATA", {}
-        )
+#         config_vocab_types = current_app.config.get(
+#             "INVENIO_VOCABULARY_TYPE_METADATA", {}
+#         )
 
-        count_terms_agg = {}
-        generic_stats = self._generic_vocabulary_statistics()
-        custom_stats = self._custom_vocabulary_statistics()
+#         count_terms_agg = {}
+#         generic_stats = self._generic_vocabulary_statistics()
+#         custom_stats = self._custom_vocabulary_statistics()
 
-        for k in generic_stats.keys() | custom_stats.keys():
-            count_terms_agg[k] = generic_stats.get(k, 0) + custom_stats.get(k, 0)
+#         for k in generic_stats.keys() | custom_stats.keys():
+#             count_terms_agg[k] = generic_stats.get(k, 0) + custom_stats.get(k, 0)
 
-        # Extend database data with configuration & aggregation data.
-        results = []
-        for db_vocab_type in vocabulary_types:
-            result = {
-                "id": db_vocab_type.id,
-                "pid_type": db_vocab_type.pid_type,
-                "count": count_terms_agg.get(db_vocab_type.id, 0),
-                "is_custom_vocabulary": db_vocab_type.id
-                in self.custom_vocabulary_names,
-            }
+#         # Extend database data with configuration & aggregation data.
+#         results = []
+#         for db_vocab_type in vocabulary_types:
+#             result = {
+#                 "id": db_vocab_type.id,
+#                 "pid_type": db_vocab_type.pid_type,
+#                 "count": count_terms_agg.get(db_vocab_type.id, 0),
+#                 "is_custom_vocabulary": db_vocab_type.id
+#                 in self.custom_vocabulary_names,
+#             }
 
-            if db_vocab_type.id in config_vocab_types:
-                for k, v in config_vocab_types[db_vocab_type.id].items():
-                    result[k] = v
+#             if db_vocab_type.id in config_vocab_types:
+#                 for k, v in config_vocab_types[db_vocab_type.id].items():
+#                     result[k] = v
 
-            results.append(result)
+#             results.append(result)
 
-        return self.config.vocabularies_listing_resultlist_cls(
-            self,
-            identity,
-            results,
-            links_tpl=LinksTemplate({"self": Link("{+api}/vocabularies")}),
-            links_item_tpl=self.links_item_tpl,
-        )
+#         return self.config.vocabularies_listing_resultlist_cls(
+#             self,
+#             identity,
+#             results,
+#             links_tpl=LinksTemplate({"self": Link("{+api}/vocabularies")}),
+#             links_item_tpl=self.links_item_tpl,
+#         )
 
-    def _custom_vocabulary_statistics(self):
-        # query database for count of terms in custom vocabularies
-        returndict = {}
-        for vocab_type in self.custom_vocabulary_names:
-            custom_service = current_service_registry.get(vocab_type)
-            record_cls = custom_service.config.record_cls
-            returndict[vocab_type] = record_cls.model_cls.query.count()
+#     def _custom_vocabulary_statistics(self):
+#         # query database for count of terms in custom vocabularies
+#         returndict = {}
+#         for vocab_type in self.custom_vocabulary_names:
+#             custom_service = current_service_registry.get(vocab_type)
+#             record_cls = custom_service.config.record_cls
+#             returndict[vocab_type] = record_cls.model_cls.query.count()
 
-        return returndict
+#         return returndict
 
-    def _generic_vocabulary_statistics(self):
-        # Opensearch query for generic vocabularies
-        config: RecordServiceConfig = current_service.config
-        search_opts = config.search
+#     def _generic_vocabulary_statistics(self):
+#         # Opensearch query for generic vocabularies
+#         config: RecordServiceConfig = current_service.config
+#         search_opts = config.search
 
-        search = search_opts.search_cls(
-            using=current_search_client,
-            index=config.record_cls.index.search_alias,
-        )
+#         search = search_opts.search_cls(
+#             using=current_search_client,
+#             index=config.record_cls.index.search_alias,
+#         )
 
-        search.aggs.bucket("vocabularies", {"terms": {"field": "type.id", "size": 100}})
+#         search.aggs.bucket("vocabularies", {"terms": {"field": "type.id", "size": 100}})
 
-        search_result = search.execute()
-        buckets = search_result.aggs.to_dict()["vocabularies"]["buckets"]
+#         search_result = search.execute()
+#         buckets = search_result.aggs.to_dict()["vocabularies"]["buckets"]
 
-        return {bucket["key"]: bucket["doc_count"] for bucket in buckets}
+#         return {bucket["key"]: bucket["doc_count"] for bucket in buckets}
 
 
 class VocabularySearchOptions(SearchOptions):

--- a/invenio_vocabularies/services/service.py
+++ b/invenio_vocabularies/services/service.py
@@ -37,6 +37,147 @@ from .schema import TaskSchema, VocabularySchema
 from .tasks import process_datastream
 
 
+def is_custom_vocabulary_type(vocabulary_type, context):
+    """Check if the vocabulary type is a custom vocabulary type."""
+    return vocabulary_type["id"] in current_app.config.get(
+        "VOCABULARIES_CUSTOM_VOCABULARY_TYPES", []
+    )
+
+
+class VocabularyMetadataList(ServiceListResult):
+    """Ensures that vocabulary metadata is returned in the proper format."""
+
+    def __init__(
+        self,
+        service,
+        identity,
+        results,
+        links_tpl=None,
+        links_item_tpl=None,
+    ):
+        """Constructor.
+
+        :params service: a service instance
+        :params identity: an identity that performed the service request
+        :params results: the search results
+        """
+        self._identity = identity
+        self._results = results
+        self._service = service
+        self._links_tpl = links_tpl
+        self._links_item_tpl = links_item_tpl
+
+    def to_dict(self):
+        """Formats result to a dict of hits."""
+        hits = list(self._results)
+
+        for hit in hits:
+            if self._links_item_tpl:
+                hit["links"] = self._links_item_tpl.expand(self._identity, hit)
+
+        res = {
+            "hits": {
+                "hits": hits,
+                "total": len(hits),
+            }
+        }
+
+        if self._links_tpl:
+            res["links"] = self._links_tpl.expand(self._identity, None)
+
+        return res
+
+
+class VocabularyTypeService(Service):
+    """Vocabulary type service."""
+
+    @property
+    def schema(self):
+        """Returns the data schema instance."""
+        return ServiceSchemaWrapper(self, schema=self.config.schema)
+
+    @property
+    def links_item_tpl(self):
+        """Item links template."""
+        return LinksTemplate(
+            self.config.vocabularies_listing_item,
+        )
+
+    @property
+    def custom_vocabulary_names(self):
+        """Checks whether vocabulary is a custom vocabulary."""
+        return current_app.config.get("VOCABULARIES_CUSTOM_VOCABULARY_TYPES", [])
+
+    def search(self, identity):
+        """Search for vocabulary types entries."""
+        self.require_permission(identity, "list_vocabularies")
+
+        vocabulary_types = VocabularyType.query.all()
+
+        config_vocab_types = current_app.config.get(
+            "INVENIO_VOCABULARY_TYPE_METADATA", {}
+        )
+
+        count_terms_agg = {}
+        generic_stats = self._generic_vocabulary_statistics()
+        custom_stats = self._custom_vocabulary_statistics()
+
+        for k in generic_stats.keys() | custom_stats.keys():
+            count_terms_agg[k] = generic_stats.get(k, 0) + custom_stats.get(k, 0)
+
+        # Extend database data with configuration & aggregation data.
+        results = []
+        for db_vocab_type in vocabulary_types:
+            result = {
+                "id": db_vocab_type.id,
+                "pid_type": db_vocab_type.pid_type,
+                "count": count_terms_agg.get(db_vocab_type.id, 0),
+                "is_custom_vocabulary": db_vocab_type.id
+                in self.custom_vocabulary_names,
+            }
+
+            if db_vocab_type.id in config_vocab_types:
+                for k, v in config_vocab_types[db_vocab_type.id].items():
+                    result[k] = v
+
+            results.append(result)
+
+        return self.config.vocabularies_listing_resultlist_cls(
+            self,
+            identity,
+            results,
+            links_tpl=LinksTemplate({"self": Link("{+api}/vocabularies")}),
+            links_item_tpl=self.links_item_tpl,
+        )
+
+    def _custom_vocabulary_statistics(self):
+        # query database for count of terms in custom vocabularies
+        returndict = {}
+        for vocab_type in self.custom_vocabulary_names:
+            custom_service = current_service_registry.get(vocab_type)
+            record_cls = custom_service.config.record_cls
+            returndict[vocab_type] = record_cls.model_cls.query.count()
+
+        return returndict
+
+    def _generic_vocabulary_statistics(self):
+        # Opensearch query for generic vocabularies
+        config: RecordServiceConfig = current_service.config
+        search_opts = config.search
+
+        search = search_opts.search_cls(
+            using=current_search_client,
+            index=config.record_cls.index.search_alias,
+        )
+
+        search.aggs.bucket("vocabularies", {"terms": {"field": "type.id", "size": 100}})
+
+        search_result = search.execute()
+        buckets = search_result.aggs.to_dict()["vocabularies"]["buckets"]
+
+        return {bucket["key"]: bucket["doc_count"] for bucket in buckets}
+
+
 class VocabularySearchOptions(SearchOptions):
     """Search options."""
 

--- a/tests/contrib/subjects/conftest.py
+++ b/tests/contrib/subjects/conftest.py
@@ -27,12 +27,9 @@ def subject_full_data():
             "de": "Darknet",
             "fr": "Réseaux anonymes (informatique)",
         },
-        "id": "1062531973",
+        "id": "http://d-nb.info/gnd/1062531973",
         "scheme": "GND",
         "synonyms": ["Deep Web"],
-        "identifiers": [
-            {"identifier": "http://d-nb.info/gnd/1062531973", "scheme": "gnd"}
-        ],
     }
 
 
@@ -45,10 +42,9 @@ def expected_subject_full_data():
             "de": "Darknet",
             "fr": "Réseaux anonymes (informatique)",
         },
-        "id": "1062531973",
+        "id": "http://d-nb.info/gnd/1062531973",
         "scheme": "GND",
         "synonyms": ["Deep Web"],
-        "identifiers": [{"identifier": "gnd:1062531973", "scheme": "gnd"}],
     }
 
 

--- a/tests/contrib/subjects/conftest.py
+++ b/tests/contrib/subjects/conftest.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2021-2022 CERN.
 # Copyright (C) 2021 Northwestern University.
+# Copyright (C) 2024 University of Münster.
 #
 # Invenio-Vocabularies is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -20,13 +21,6 @@ from invenio_records_resources.proxies import current_service_registry
 @pytest.fixture(scope="function")
 def subject_full_data():
     """Controlled vocabulary backed subject data."""
-    """
-    return {
-        "id": "https://id.nlm.nih.gov/mesh/D000001",
-        "scheme": "MeSH",
-        "subject": "Calcimycin",
-    }
-    """
     return {
         "subject": {
             "en": "Dark Web",
@@ -39,6 +33,22 @@ def subject_full_data():
         "identifiers": [
             {"identifier": "http://d-nb.info/gnd/1062531973", "scheme": "gnd"}
         ],
+    }
+
+
+@pytest.fixture(scope="function")
+def expected_subject_full_data():
+    """Controlled vocabulary backed subject data."""
+    return {
+        "subject": {
+            "en": "Dark Web",
+            "de": "Darknet",
+            "fr": "Réseaux anonymes (informatique)",
+        },
+        "id": "1062531973",
+        "scheme": "GND",
+        "synonyms": ["Deep Web"],
+        "identifiers": [{"identifier": "gnd:1062531973", "scheme": "gnd"}],
     }
 
 

--- a/tests/contrib/subjects/conftest.py
+++ b/tests/contrib/subjects/conftest.py
@@ -20,10 +20,25 @@ from invenio_records_resources.proxies import current_service_registry
 @pytest.fixture(scope="function")
 def subject_full_data():
     """Controlled vocabulary backed subject data."""
+    """
     return {
         "id": "https://id.nlm.nih.gov/mesh/D000001",
         "scheme": "MeSH",
         "subject": "Calcimycin",
+    }
+    """
+    return {
+        "subject": {
+            "en": "Dark Web",
+            "de": "Darknet",
+            "fr": "Réseaux anonymes (informatique)",
+        },
+        "id": "1062531973",
+        "scheme": "GND",
+        "synonyms": ["Deep Web"],
+        "identifiers": [
+            {"identifier": "http://d-nb.info/gnd/1062531973", "scheme": "gnd"}
+        ],
     }
 
 

--- a/tests/contrib/subjects/test_subjects_api.py
+++ b/tests/contrib/subjects/test_subjects_api.py
@@ -64,6 +64,6 @@ def test_subject_pid(app, db, example_subject):
     """Test subject pid creation."""
     subj = example_subject
 
-    assert subj.pid.pid_value == "1062531973"
+    assert subj.pid.pid_value == "http://d-nb.info/gnd/1062531973"
     assert subj.pid.pid_type == "sub"
-    assert Subject.pid.resolve("1062531973")
+    assert Subject.pid.resolve("http://d-nb.info/gnd/1062531973")

--- a/tests/contrib/subjects/test_subjects_api.py
+++ b/tests/contrib/subjects/test_subjects_api.py
@@ -64,6 +64,6 @@ def test_subject_pid(app, db, example_subject):
     """Test subject pid creation."""
     subj = example_subject
 
-    assert subj.pid.pid_value == "https://id.nlm.nih.gov/mesh/D000001"
+    assert subj.pid.pid_value == "1062531973"
     assert subj.pid.pid_type == "sub"
-    assert Subject.pid.resolve("https://id.nlm.nih.gov/mesh/D000001")
+    assert Subject.pid.resolve("1062531973")

--- a/tests/contrib/subjects/test_subjects_datastreams.py
+++ b/tests/contrib/subjects/test_subjects_datastreams.py
@@ -1,32 +1,100 @@
-from unittest.mock import mock_open, patch
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 University of Münster.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
 
+"""Subject datastream tests."""
+import logging
+from pathlib import Path
+
+import idutils
 import pytest
 
-from invenio_vocabularies.contrib.subjects.datastreams import (
-    SubjectsYAMLReader,
-    SubjectsYAMLTransformer,
-)
+from invenio_vocabularies.contrib.subjects.datastreams import YAMLTransformer
 from invenio_vocabularies.datastreams import StreamEntry
+from invenio_vocabularies.datastreams.readers import YamlReader
+
+subject_schemes = {
+    "gnd": {"label": "GND", "validator": idutils.is_gnd, "datacite": "GND"},
+}
+
+
+@pytest.fixture(scope="module")
+def subject_as_yaml():
+    subject = """
+        - subject:
+              en: Dark Web
+              de: Darknet
+              fr: Réseaux anonymes (informatique)
+          id: "1062531973"
+          scheme: GND
+          synonyms:
+          - Deep Web
+          identifiers:
+          - http://d-nb.info/gnd/1062531973
+          - http://id.loc.gov/authorities/subjects/sh2018002121
+          - https://d-nb.info/gnd/1062531973
+    """
+    return subject
+
+
+@pytest.fixture(scope="function")
+def yaml_file(subject_as_yaml):
+    filename = Path("reader_test.yaml")
+    with open(filename, "w") as file:
+        file.write(subject_as_yaml)
+
+    yield filename
+
+    filename.unlink()  # delete created file
 
 
 @pytest.fixture(scope="module")
 def dict_subject_entry():
     return StreamEntry(
         {
-            "subject": "Test Subject",
-            "id": "123",
-            "scheme": "Test Scheme",
+            "subject": {
+                "en": "Dark Web",
+                "de": "Darknet",
+                "fr": "Réseaux anonymes (informatique)",
+            },
+            "id": "1062531973",
+            "scheme": "GND",
+            "synonyms": ["Deep Web"],
+            "identifiers": [
+                "http://d-nb.info/gnd/1062531973",
+                "http://id.loc.gov/authorities/subjects/sh2018002121",
+                "https://d-nb.info/gnd/1062531973",
+            ],
         },
     )
 
 
-def test_transformer(dict_subject_entry):
-    transformer = SubjectsYAMLTransformer()
+def test_transformer(dict_subject_entry, yaml_file):
+    reader = YamlReader(yaml_file)
+    yaml_content = []
+    for _, entry in enumerate(reader.read()):
+        yaml_content.append(StreamEntry(entry))
 
-    transformed_entry = transformer.apply(dict_subject_entry)
+    logging.warning(yaml_content)
+
+    transformer = YAMLTransformer(vocab_schemes=subject_schemes)
+
+    transformed_entry = transformer.apply(yaml_content[0])
 
     assert transformed_entry == {
-        "subject": "Test Subject",
-        "id": "123",
-        "scheme": "Test Scheme",
+        "subject": {
+            "en": "Dark Web",
+            "de": "Darknet",
+            "fr": "Réseaux anonymes (informatique)",
+        },
+        "id": "1062531973",
+        "scheme": "GND",
+        "synonyms": ["Deep Web"],
+        "identifiers": [
+            {"identifier": "http://d-nb.info/gnd/1062531973", "scheme": "gnd"}
+        ],
     }

--- a/tests/contrib/subjects/test_subjects_datastreams.py
+++ b/tests/contrib/subjects/test_subjects_datastreams.py
@@ -1,0 +1,63 @@
+from unittest.mock import mock_open, patch
+
+import pytest
+
+from invenio_vocabularies.contrib.subjects.datastreams import (
+    SubjectsYAMLReader,
+    SubjectsYAMLTransformer,
+)
+from invenio_vocabularies.datastreams import StreamEntry
+
+
+def test_read():
+    # Arrange
+    mock_yaml_data = [
+        [
+            {
+                "id": "http://www.oecd.org/science/inno/38235147.pdf?6.5",
+                "scheme": "FOS",
+                "subject": "Other humanities",
+            }
+        ]
+    ]
+    reader = SubjectsYAMLReader(options={"filename": "subjects.yaml"})
+
+    with patch(
+        "builtins.open",
+        mock_open(
+            read_data='- id: "http://www.oecd.org/science/inno/38235147.pdf?6.5"\\n  scheme: FOS\\n  subject: "Other humanities"'
+        ),
+    ) as m:
+        with patch("yaml.safe_load", return_value=mock_yaml_data) as mock_yaml:
+
+            data = list(reader.read())  # Convert the generator to a list to consume it
+
+            m.assert_called_once_with("subjects.yaml", "r")
+            mock_yaml.assert_called_once()
+
+            assert (
+                data == mock_yaml_data
+            )  # Check that the data returned by read is correct
+
+
+@pytest.fixture(scope="module")
+def dict_subject_entry():
+    return StreamEntry(
+        {
+            "subject": "Test Subject",
+            "id": "123",
+            "scheme": "Test Scheme",
+        },
+    )
+
+
+def test_transformer(dict_subject_entry):
+    transformer = SubjectsYAMLTransformer()
+
+    transformed_entry = transformer.apply(dict_subject_entry)
+
+    assert transformed_entry == {
+        "subject": "Test Subject",
+        "id": "123",
+        "scheme": "Test Scheme",
+    }

--- a/tests/contrib/subjects/test_subjects_datastreams.py
+++ b/tests/contrib/subjects/test_subjects_datastreams.py
@@ -29,14 +29,10 @@ def subject_as_yaml():
               en: Dark Web
               de: Darknet
               fr: Réseaux anonymes (informatique)
-          id: "1062531973"
+          id: "http://d-nb.info/gnd/1062531973"
           scheme: GND
           synonyms:
           - Deep Web
-          identifiers:
-          - http://d-nb.info/gnd/1062531973
-          - http://id.loc.gov/authorities/subjects/sh2018002121
-          - https://d-nb.info/gnd/1062531973
     """
     return subject
 
@@ -61,14 +57,9 @@ def dict_subject_entry():
                 "de": "Darknet",
                 "fr": "Réseaux anonymes (informatique)",
             },
-            "id": "1062531973",
+            "id": "http://d-nb.info/gnd/1062531973",
             "scheme": "GND",
             "synonyms": ["Deep Web"],
-            "identifiers": [
-                "http://d-nb.info/gnd/1062531973",
-                "http://id.loc.gov/authorities/subjects/sh2018002121",
-                "https://d-nb.info/gnd/1062531973",
-            ],
         },
     )
 
@@ -91,10 +82,7 @@ def test_transformer(dict_subject_entry, yaml_file):
             "de": "Darknet",
             "fr": "Réseaux anonymes (informatique)",
         },
-        "id": "1062531973",
+        "id": "http://d-nb.info/gnd/1062531973",
         "scheme": "GND",
         "synonyms": ["Deep Web"],
-        "identifiers": [
-            {"identifier": "http://d-nb.info/gnd/1062531973", "scheme": "gnd"}
-        ],
     }

--- a/tests/contrib/subjects/test_subjects_datastreams.py
+++ b/tests/contrib/subjects/test_subjects_datastreams.py
@@ -9,37 +9,6 @@ from invenio_vocabularies.contrib.subjects.datastreams import (
 from invenio_vocabularies.datastreams import StreamEntry
 
 
-def test_read():
-    # Arrange
-    mock_yaml_data = [
-        [
-            {
-                "id": "http://www.oecd.org/science/inno/38235147.pdf?6.5",
-                "scheme": "FOS",
-                "subject": "Other humanities",
-            }
-        ]
-    ]
-    reader = SubjectsYAMLReader(options={"filename": "subjects.yaml"})
-
-    with patch(
-        "builtins.open",
-        mock_open(
-            read_data='- id: "http://www.oecd.org/science/inno/38235147.pdf?6.5"\\n  scheme: FOS\\n  subject: "Other humanities"'
-        ),
-    ) as m:
-        with patch("yaml.safe_load", return_value=mock_yaml_data) as mock_yaml:
-
-            data = list(reader.read())  # Convert the generator to a list to consume it
-
-            m.assert_called_once_with("subjects.yaml", "r")
-            mock_yaml.assert_called_once()
-
-            assert (
-                data == mock_yaml_data
-            )  # Check that the data returned by read is correct
-
-
 @pytest.fixture(scope="module")
 def dict_subject_entry():
     return StreamEntry(

--- a/tests/contrib/subjects/test_subjects_jsonschema.py
+++ b/tests/contrib/subjects/test_subjects_jsonschema.py
@@ -48,13 +48,10 @@ def test_valid_full(appctx, schema):
             "de": "Darknet",
             "fr": "Réseaux anonymes (informatique)",
         },
-        "id": "1062531973",
+        "id": "http://d-nb.info/gnd/1062531973",
         "pid": {"pk": 1, "status": "R", "pid_type": "subid", "obj_type": "sub"},
         "scheme": "GND",
         "synonyms": ["Deep Web"],
-        "identifiers": [
-            {"identifier": "http://d-nb.info/gnd/1062531973", "scheme": "gnd"}
-        ],
     }
     assert validates(data)
 

--- a/tests/contrib/subjects/test_subjects_jsonschema.py
+++ b/tests/contrib/subjects/test_subjects_jsonschema.py
@@ -41,7 +41,21 @@ def test_valid_full(appctx, schema):
         "scheme": "MeSH",
         "subject": "Calcimycin",
     }
-
+    data = {
+        "$schema": schema,
+        "subject": {
+            "en": "Dark Web",
+            "de": "Darknet",
+            "fr": "Réseaux anonymes (informatique)",
+        },
+        "id": "1062531973",
+        "pid": {"pk": 1, "status": "R", "pid_type": "subid", "obj_type": "sub"},
+        "scheme": "GND",
+        "synonyms": ["Deep Web"],
+        "identifiers": [
+            {"identifier": "http://d-nb.info/gnd/1062531973", "scheme": "gnd"}
+        ],
+    }
     assert validates(data)
 
 

--- a/tests/contrib/subjects/test_subjects_resource.py
+++ b/tests/contrib/subjects/test_subjects_resource.py
@@ -39,7 +39,7 @@ def test_get(client, h, prefix, example_subject):
     assert res.json["id"] == id_
     # links are encoded which seems weird
     assert res.json["links"] == {
-        "self": "https://127.0.0.1:5000/api/subjects/1062531973"  # noqa
+        "self": "https://127.0.0.1:5000/api/subjects/http%3A%2F%2Fd-nb.info%2Fgnd%2F1062531973"  # noqa
     }
     # but they should still resolve
     i = res.json["links"]["self"].find("subjects")

--- a/tests/contrib/subjects/test_subjects_resource.py
+++ b/tests/contrib/subjects/test_subjects_resource.py
@@ -39,7 +39,7 @@ def test_get(client, h, prefix, example_subject):
     assert res.json["id"] == id_
     # links are encoded which seems weird
     assert res.json["links"] == {
-        "self": "https://127.0.0.1:5000/api/subjects/https%3A%2F%2Fid.nlm.nih.gov%2Fmesh%2FD000001"  # noqa
+        "self": "https://127.0.0.1:5000/api/subjects/1062531973"  # noqa
     }
     # but they should still resolve
     i = res.json["links"]["self"].find("subjects")
@@ -72,7 +72,7 @@ def test_forbidden_endpoints(client, h, prefix, example_subject, subject_full_da
 
 def test_search(client, h, prefix, example_subject):
     """Test a successful search."""
-    res = client.get(prefix, headers=h)
+    res = client.get(f"{prefix}", headers=h)
 
     assert res.status_code == 200
     assert res.json["hits"]["total"] == 1
@@ -85,27 +85,37 @@ def example_subjects(app, db, search_clear, identity, service):
         {
             "id": "other-1",
             "scheme": "Other",
-            "subject": "Abdomen",
+            "subject": {
+                "en": "Abdomen",
+            },
         },
         {
             "id": "https://id.nlm.nih.gov/mesh/D000001",
             "scheme": "MeSH",
-            "subject": "Calcimycin",
+            "subject": {
+                "en": "Calcimycin",
+            },
         },
         {
             "id": "https://id.nlm.nih.gov/mesh/D000005",
             "scheme": "MeSH",
-            "subject": "Abdomen",
+            "subject": {
+                "en": "Abdomen",
+            },
         },
         {
             "id": "https://id.nlm.nih.gov/mesh/D000006",
             "scheme": "MeSH",
-            "subject": "Abdomen, Acute",
+            "subject": {
+                "en": "Abdomen, Acute",
+            },
         },
         {
             "id": "yet-another-954514",
             "scheme": "Other2",
-            "subject": "Abdomen",
+            "subject": {
+                "en": "Abdomen",
+            },
         },
     ]
     records = [service.create(identity, s) for s in subjects]

--- a/tests/contrib/subjects/test_subjects_schema.py
+++ b/tests/contrib/subjects/test_subjects_schema.py
@@ -20,6 +20,12 @@ from invenio_vocabularies.contrib.subjects.schema import (
 )
 
 
+def test_valid_full(app, subject_full_data):
+    loaded = SubjectSchema().load(subject_full_data)
+    assert subject_full_data == loaded
+
+
+"""
 class TestSubjectSchema:
     def test_valid_full(self, subject_full_data):
         loaded = SubjectSchema().load(subject_full_data)
@@ -67,3 +73,4 @@ class TestSubjectRelationSchema:
 
         subject = {"subject": "Entity One", "scheme": "scheme A"}
         assert subject == SubjectRelationSchema().dump(subject)
+"""

--- a/tests/contrib/subjects/test_subjects_schema.py
+++ b/tests/contrib/subjects/test_subjects_schema.py
@@ -14,10 +14,7 @@ from copy import copy
 import pytest
 from marshmallow import ValidationError
 
-from invenio_vocabularies.contrib.subjects.schema import (
-    SubjectRelationSchema,
-    SubjectSchema,
-)
+from invenio_vocabularies.contrib.subjects.schema import SubjectSchema
 
 
 def test_valid_full(app, subject_full_data, expected_subject_full_data):
@@ -37,37 +34,3 @@ def test_invalid_missing_field(app, subject_full_data):
     del invalid["scheme"]
     with pytest.raises(ValidationError):
         SubjectSchema().load(invalid)
-
-
-"""
-    # no subject
-    invalid = copy(subject_full_data)
-    del invalid["subject"]
-    with pytest.raises(ValidationError):
-        SubjectSchema().load(invalid)
-"""
-
-"""
-class TestSubjectRelationSchema:
-    def test_valid_id(self):
-        valid_id = {
-            "id": "test",
-        }
-        assert valid_id == SubjectRelationSchema().load(valid_id)
-
-    def test_valid_subject(self):
-        valid_subject = {"subject": "Entity One"}
-        assert valid_subject == SubjectRelationSchema().load(valid_subject)
-
-    def test_invalid_empty(self):
-        invalid_empty = {}
-        with pytest.raises(ValidationError):
-            SubjectRelationSchema().load(invalid_empty)
-
-    def test_dump(self):
-        subject = {"subject": "Entity One"}
-        assert {"subject": "Entity One"} == SubjectRelationSchema().dump(subject)
-
-        subject = {"subject": "Entity One", "scheme": "scheme A"}
-        assert subject == SubjectRelationSchema().dump(subject)
-"""

--- a/tests/contrib/subjects/test_subjects_schema.py
+++ b/tests/contrib/subjects/test_subjects_schema.py
@@ -20,37 +20,34 @@ from invenio_vocabularies.contrib.subjects.schema import (
 )
 
 
-def test_valid_full(app, subject_full_data):
+def test_valid_full(app, subject_full_data, expected_subject_full_data):
     loaded = SubjectSchema().load(subject_full_data)
-    assert subject_full_data == loaded
+    assert expected_subject_full_data == loaded
+
+
+def test_invalid_missing_field(app, subject_full_data):
+    # no id
+    invalid = copy(subject_full_data)
+    del invalid["id"]
+    with pytest.raises(ValidationError):
+        SubjectSchema().load(invalid)
+
+    # no scheme
+    invalid = copy(subject_full_data)
+    del invalid["scheme"]
+    with pytest.raises(ValidationError):
+        SubjectSchema().load(invalid)
 
 
 """
-class TestSubjectSchema:
-    def test_valid_full(self, subject_full_data):
-        loaded = SubjectSchema().load(subject_full_data)
-        assert subject_full_data == loaded
+    # no subject
+    invalid = copy(subject_full_data)
+    del invalid["subject"]
+    with pytest.raises(ValidationError):
+        SubjectSchema().load(invalid)
+"""
 
-    def test_invalid_missing_field(self, subject_full_data):
-        # no id
-        invalid = copy(subject_full_data)
-        del invalid["id"]
-        with pytest.raises(ValidationError):
-            SubjectSchema().load(invalid)
-
-        # no scheme
-        invalid = copy(subject_full_data)
-        del invalid["scheme"]
-        with pytest.raises(ValidationError):
-            SubjectSchema().load(invalid)
-
-        # no subject
-        invalid = copy(subject_full_data)
-        del invalid["subject"]
-        with pytest.raises(ValidationError):
-            SubjectSchema().load(invalid)
-
-
+"""
 class TestSubjectRelationSchema:
     def test_valid_id(self):
         valid_id = {

--- a/tests/contrib/subjects/test_subjects_service.py
+++ b/tests/contrib/subjects/test_subjects_service.py
@@ -34,7 +34,7 @@ def test_subject_simple_flow(
         assert data[k] == v, data
 
     # Read it
-    read_item = service.read(identity, "1062531973")
+    read_item = service.read(identity, "http://d-nb.info/gnd/1062531973")
     assert item.id == read_item.id
     assert item.data == read_item.data
 

--- a/tests/contrib/subjects/test_subjects_service.py
+++ b/tests/contrib/subjects/test_subjects_service.py
@@ -16,7 +16,9 @@ from invenio_pidstore.errors import PIDDeletedError
 from invenio_vocabularies.contrib.subjects.api import Subject
 
 
-def test_subject_simple_flow(app, db, service, identity, subject_full_data):
+def test_subject_simple_flow(
+    app, db, service, identity, subject_full_data, expected_subject_full_data
+):
     """Test a simple vocabulary service flow."""
     # Service
     assert service.id == "subjects"
@@ -27,12 +29,12 @@ def test_subject_simple_flow(app, db, service, identity, subject_full_data):
     id_ = item.id
     data = item.data
 
-    assert id_ == subject_full_data["id"]
-    for k, v in subject_full_data.items():
+    assert id_ == expected_subject_full_data["id"]
+    for k, v in expected_subject_full_data.items():
         assert data[k] == v, data
 
     # Read it
-    read_item = service.read(identity, "https://id.nlm.nih.gov/mesh/D000001")
+    read_item = service.read(identity, "1062531973")
     assert item.id == read_item.id
     assert item.data == read_item.data
 
@@ -48,10 +50,10 @@ def test_subject_simple_flow(app, db, service, identity, subject_full_data):
 
     # Update it
     data = read_item.data
-    data["subject"] = "Antibiotics"
+    data["subject"]["en"] = "Antibiotics"
     update_item = service.update(identity, id_, data)
     assert item.id == update_item.id
-    assert update_item["subject"] == "Antibiotics"
+    assert update_item["subject"]["en"] == "Antibiotics"
 
     # Delete it
     assert service.delete(identity, id_)


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

I started with what I was thinking were essential in porting subjects to datastreams. There already has been a `YamlReader` and a `CSVReader` which we will use to keep backwards compatibility to the current way of loading subjects from files. I added a `SubjectsYAMLTransformer` that is somehow redundant because the dict returned by the YAML reader is basically the same as what the reader returns. But it might me useful at some point I guess?

I thinks whats missing is the implementation of a writer method similar to `VocabularyEntryWithSchemes` in invenio-rdm-records (https://github.com/inveniosoftware/invenio-rdm-records/blob/master/invenio_rdm_records/fixtures/vocabularies.py#L383)
