### PR TITLE
release: v4.0.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,16 @@
 Changes
 =======
 
+Version 4.0.0 (released 2024-06-04)
+
+- datastreams: implement factories for generating vocabulary configurations
+- datastreams: added ROR HTTP reader
+- funders: use ROR v2 dump instead of v1
+- datastreams: added celery task for funders using ROR HTTP reader
+- datastreams: add OpenAIRE Project HTTP Reader
+- datastreams: fix OpenAIRE graph dataset parsing
+- installation: upgrade invenio-records-resources
+
 Version 3.4.0 (released 2024-04-19)
 
 - templates: add subject fields UI template (#303)

--- a/invenio_vocabularies/__init__.py
+++ b/invenio_vocabularies/__init__.py
@@ -10,6 +10,6 @@
 
 from .ext import InvenioVocabularies
 
-__version__ = "3.4.0"
+__version__ = "4.0.0"
 
 __all__ = ("__version__", "InvenioVocabularies")

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ python_requires = >=3.7
 zip_safe = False
 install_requires =
     invenio-i18n>=2.0.0,<3.0.0
-    invenio-records-resources>=5.0.0,<6.0.0
+    invenio-records-resources>=6.0.0,<7.0.0
     lxml>=4.5.0
     PyYAML>=5.4.1
 


### PR DESCRIPTION
- Major release of `invenio-vocabularies` due to breaking changes in CLI and added mappings
- Major bump of `invenio-records-resources`