### PR TITLE
Fix funders show country

### DIFF
--- a/invenio_vocabularies/assets/semantic-ui/js/invenio_vocabularies/src/contrib/forms/Funding/CustomAwardForm.js
+++ b/invenio_vocabularies/assets/semantic-ui/js/invenio_vocabularies/src/contrib/forms/Funding/CustomAwardForm.js
@@ -16,21 +16,9 @@ import Overridable from "react-overridable";
 
 function CustomAwardForm({ deserializeFunder, selectedFunding }) {
   function deserializeFunderToDropdown(funderItem) {
-    let funderName = null;
-    let funderPID = null;
-    let funderCountry = null;
-
-    if (funderItem.name) {
-      funderName = funderItem.name;
-    }
-
-    if (funderItem.id) {
-      funderPID = funderItem.id;
-    }
-
-    if (funderItem.country_name) {
-      funderCountry = funderItem.country_name;
-    }
+    const funderName = funderItem?.name;
+    const funderPID = funderItem?.id;
+    const funderCountry = funderItem?.country_name;
 
     if (!funderName && !funderPID) {
       return {};

--- a/invenio_vocabularies/assets/semantic-ui/js/invenio_vocabularies/src/contrib/forms/Funding/CustomAwardForm.js
+++ b/invenio_vocabularies/assets/semantic-ui/js/invenio_vocabularies/src/contrib/forms/Funding/CustomAwardForm.js
@@ -18,7 +18,7 @@ function CustomAwardForm({ deserializeFunder, selectedFunding }) {
   function deserializeFunderToDropdown(funderItem) {
     const funderName = funderItem?.name;
     const funderPID = funderItem?.id;
-    const funderCountry = funderItem?.country_name;
+    const funderCountry = funderItem?.country_name ?? funderItem?.country;
 
     if (!funderName && !funderPID) {
       return {};

--- a/invenio_vocabularies/contrib/funders/serializer.py
+++ b/invenio_vocabularies/contrib/funders/serializer.py
@@ -29,4 +29,5 @@ class FunderL10NItemSchema(Schema):
     props = fields.Dict(dump_only=True)
     name = fields.String(dump_only=True)
     country = fields.String(dump_only=True)
+    country_name = fields.String(dump_only=True)
     identifiers = fields.List(fields.Nested(IdentifierSchema), dump_only=True)


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* Fixes #342

#### :walking: Review path

* The 1st commit includes the country_name in the API response for funders which have a country_name (recently  updated ones)
* The pull request inveniosoftware/invenio-app-rdm#2704 modifies `deserializeFunder` to pass include country_name in the deserialized form of funder items.
* The 2nd commit simplifies the logic of `deserializeFunderToDropdown` by using optional chaining
* The 3rd commit modifies `deserializeFunderToDropdown` to shows the country code for existing funders which don't have yet a country_name
* Note that the modified `deserializeFunder` function is used lower down in the `render` function of `CustomAwardForm`.

#### :shrug: Open questions

Places which might need to be modified to also include country_name:

- [ ] [FundingField's deserializeFunder](https://github.com/inveniosoftware/invenio-vocabularies/blob/master/invenio_vocabularies/assets/semantic-ui/js/invenio_vocabularies/src/contrib/forms/Funding/FundingField.js#L57)
- [ ] [FundersLabels's fields](https://github.com/inveniosoftware/invenio-vocabularies/blob/master/invenio_vocabularies/contrib/funders/facets.py#L32)
- [ ] [FundersLabels's _vocab_to_label](https://github.com/inveniosoftware/invenio-vocabularies/blob/master/invenio_vocabularies/contrib/funders/facets.py#L36)

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
