### PR TITLE
contrib: names: update field boosts and mapping

### DIFF
--- a/invenio_vocabularies/contrib/names/config.py
+++ b/invenio_vocabularies/contrib/names/config.py
@@ -28,12 +28,16 @@ class NamesSearchOptions(SearchOptions):
 
     suggest_parser_cls = SuggestQueryParser.factory(
         fields=[
-            "name^100",
-            "family_name^100",
+            "name.suggest^80",
+            "name^80",
+            "family_name^70",
+            "given_name.suggest^100",
             "given_name^100",
             "identifiers.identifier^20",
             "affiliations.name^10",
-        ],
+        ],  # type has to be bool_prefix to use suggest._index_prefix field during querying
+        operator="AND",
+        fuzziness="AUTO",
     )
 
     sort_default = "bestmatch"

--- a/invenio_vocabularies/contrib/names/config.py
+++ b/invenio_vocabularies/contrib/names/config.py
@@ -28,15 +28,13 @@ class NamesSearchOptions(SearchOptions):
 
     suggest_parser_cls = SuggestQueryParser.factory(
         fields=[
-            "name.suggest^80",
-            "name^80",
-            "family_name^70",
-            "given_name.suggest^100",
             "given_name^100",
+            "name^70",
+            "family_name^50",
             "identifiers.identifier^20",
-            "affiliations.name^10",
-        ],  # type has to be bool_prefix to use suggest._index_prefix field during querying
-        operator="AND",
+            "affiliations.name^20",
+        ],
+        type="most_fields",  # https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html#multi-match-types
         fuzziness="AUTO",
     )
 

--- a/invenio_vocabularies/contrib/names/mappings/os-v1/names/name-v2.0.0.json
+++ b/invenio_vocabularies/contrib/names/mappings/os-v1/names/name-v2.0.0.json
@@ -125,6 +125,16 @@
           "char_filter": ["strip_special_chars"],
           "filter": ["lowercase", "asciifolding"]
         }
+      },
+      "filter": {
+        "lowercase": {
+          "type": "lowercase",
+          "preserve_original": true
+        },
+        "asciifolding": {
+          "type": "asciifolding",
+          "preserve_original": true
+        }
       }
     }
   }

--- a/invenio_vocabularies/contrib/names/mappings/os-v1/names/name-v2.0.0.json
+++ b/invenio_vocabularies/contrib/names/mappings/os-v1/names/name-v2.0.0.json
@@ -9,11 +9,34 @@
         }
       },
       "analyzer": {
+        "accent_edge_analyzer": {
+          "tokenizer": "standard",
+          "type": "custom",
+          "char_filter": ["strip_special_chars"],
+          "filter": [
+            "lowercase",
+            "asciifolding",
+            "edgegrams"
+          ]
+        },
         "accent_analyzer": {
           "tokenizer": "standard",
           "type": "custom",
           "char_filter": ["strip_special_chars"],
-          "filter": ["lowercase", "asciifolding"]
+          "filter": [
+            "lowercase",
+            "asciifolding"
+          ]
+        }
+      },
+      "normalizer": {
+        "accent_normalizer": {
+          "type": "custom",
+          "char_filter": ["strip_special_chars"],
+          "filter": [
+            "lowercase",
+            "asciifolding"
+          ]
         }
       },
       "filter": {
@@ -24,6 +47,11 @@
         "asciifolding": {
           "type": "asciifolding",
           "preserve_original": true
+        },
+        "edgegrams": {
+          "type": "edge_ngram",
+          "min_gram": 2,
+          "max_gram": 20
         }
       }
     }
@@ -61,26 +89,14 @@
       },
       "name": {
         "type": "text",
-        "analyzer": "accent_analyzer",
+        "analyzer": "accent_edge_analyzer",
         "search_analyzer": "accent_analyzer",
-        "copy_to": "name_sort",
-        "fields": {
-          "suggest": {
-            "type": "search_as_you_type",
-            "analyzer": "accent_analyzer",
-            "search_analyzer": "accent_analyzer"
-          }
-        }
+        "copy_to": "name_sort"
       },
       "given_name": {
         "type": "text",
-        "fields": {
-          "suggest": {
-            "type": "search_as_you_type",
-            "analyzer": "accent_analyzer",
-            "search_analyzer": "accent_analyzer"
-          }
-        }
+        "analyzer": "accent_edge_analyzer",
+        "search_analyzer": "accent_analyzer"
       },
       "family_name": {
         "type": "text"
@@ -89,11 +105,7 @@
         "properties": {
           "identifier": {
             "type": "keyword",
-            "fields": {
-              "suggest": {
-                "type": "search_as_you_type"
-              }
-            }
+            "normalizer": "accent_normalizer"
           },
           "scheme": {
             "type": "keyword"
@@ -110,12 +122,9 @@
             "type": "keyword"
           },
           "name": {
-            "type": "keyword",
-            "fields": {
-              "suggest": {
-                "type": "search_as_you_type"
-              }
-            }
+            "type": "text",
+            "analyzer": "accent_edge_analyzer",
+            "search_analyzer": "accent_analyzer"
           }
         }
       },

--- a/invenio_vocabularies/contrib/names/mappings/os-v1/names/name-v2.0.0.json
+++ b/invenio_vocabularies/contrib/names/mappings/os-v1/names/name-v2.0.0.json
@@ -1,0 +1,131 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "$schema": {
+        "type": "keyword",
+        "index": "false"
+      },
+      "created": {
+        "type": "date"
+      },
+      "updated": {
+        "type": "date"
+      },
+      "indexed_at": {
+        "type": "date"
+      },
+      "uuid": {
+        "type": "keyword"
+      },
+      "version_id": {
+        "type": "integer"
+      },
+      "id": {
+        "type": "keyword"
+      },
+      "tags": {
+        "type": "keyword"
+      },
+      "name_sort": {
+        "type": "keyword"
+      },
+      "name": {
+        "type": "text",
+        "analyzer": "accent_analyzer",
+        "search_analyzer": "accent_analyzer",
+        "copy_to": "name_sort",
+        "fields": {
+          "suggest": {
+            "type": "search_as_you_type",
+            "analyzer": "accent_analyzer",
+            "search_analyzer": "accent_analyzer"
+          }
+        }
+      },
+      "given_name": {
+        "type": "text",
+        "fields": {
+          "suggest": {
+            "type": "search_as_you_type",
+            "analyzer": "accent_analyzer",
+            "search_analyzer": "accent_analyzer"
+          }
+        }
+      },
+      "family_name": {
+        "type": "text"
+      },
+      "identifiers": {
+        "properties": {
+          "identifier": {
+            "type": "keyword",
+            "fields": {
+              "suggest": {
+                "type": "search_as_you_type"
+              }
+            }
+          },
+          "scheme": {
+            "type": "keyword"
+          }
+        }
+      },
+      "affiliations": {
+        "type": "object",
+        "properties": {
+          "@v": {
+            "type": "keyword"
+          },
+          "id": {
+            "type": "keyword"
+          },
+          "name": {
+            "type": "keyword",
+            "fields": {
+              "suggest": {
+                "type": "search_as_you_type"
+              }
+            }
+          }
+        }
+      },
+      "pid": {
+        "type": "object",
+        "properties": {
+          "pk": {
+            "type": "integer"
+          },
+          "pid_type": {
+            "type": "keyword"
+          },
+          "obj_type": {
+            "type": "keyword"
+          },
+          "status": {
+            "type": "keyword"
+          }
+        }
+      }
+    }
+  },
+  "settings": {
+    "analysis": {
+      "char_filter": {
+        "strip_special_chars": {
+          "type": "pattern_replace",
+          "pattern": "[\\p{Punct}\\p{S}]",
+          "replacement": ""
+        }
+      },
+      "analyzer": {
+        "accent_analyzer": {
+          "tokenizer": "standard",
+          "type": "custom",
+          "char_filter": ["strip_special_chars"],
+          "filter": ["lowercase", "asciifolding"]
+        }
+      }
+    }
+  }
+}

--- a/invenio_vocabularies/contrib/names/mappings/os-v1/names/name-v2.0.0.json
+++ b/invenio_vocabularies/contrib/names/mappings/os-v1/names/name-v2.0.0.json
@@ -1,4 +1,33 @@
 {
+  "settings": {
+    "analysis": {
+      "char_filter": {
+        "strip_special_chars": {
+          "type": "pattern_replace",
+          "pattern": "[\\p{Punct}\\p{S}]",
+          "replacement": ""
+        }
+      },
+      "analyzer": {
+        "accent_analyzer": {
+          "tokenizer": "standard",
+          "type": "custom",
+          "char_filter": ["strip_special_chars"],
+          "filter": ["lowercase", "asciifolding"]
+        }
+      },
+      "filter": {
+        "lowercase": {
+          "type": "lowercase",
+          "preserve_original": true
+        },
+        "asciifolding": {
+          "type": "asciifolding",
+          "preserve_original": true
+        }
+      }
+    }
+  },
   "mappings": {
     "dynamic": "strict",
     "properties": {
@@ -105,35 +134,6 @@
           "status": {
             "type": "keyword"
           }
-        }
-      }
-    }
-  },
-  "settings": {
-    "analysis": {
-      "char_filter": {
-        "strip_special_chars": {
-          "type": "pattern_replace",
-          "pattern": "[\\p{Punct}\\p{S}]",
-          "replacement": ""
-        }
-      },
-      "analyzer": {
-        "accent_analyzer": {
-          "tokenizer": "standard",
-          "type": "custom",
-          "char_filter": ["strip_special_chars"],
-          "filter": ["lowercase", "asciifolding"]
-        }
-      },
-      "filter": {
-        "lowercase": {
-          "type": "lowercase",
-          "preserve_original": true
-        },
-        "asciifolding": {
-          "type": "asciifolding",
-          "preserve_original": true
         }
       }
     }

--- a/invenio_vocabularies/contrib/names/mappings/os-v2/names/name-v2.0.0.json
+++ b/invenio_vocabularies/contrib/names/mappings/os-v2/names/name-v2.0.0.json
@@ -125,6 +125,16 @@
           "char_filter": ["strip_special_chars"],
           "filter": ["lowercase", "asciifolding"]
         }
+      },
+      "filter": {
+        "lowercase": {
+          "type": "lowercase",
+          "preserve_original": true
+        },
+        "asciifolding": {
+          "type": "asciifolding",
+          "preserve_original": true
+        }
       }
     }
   }

--- a/invenio_vocabularies/contrib/names/mappings/os-v2/names/name-v2.0.0.json
+++ b/invenio_vocabularies/contrib/names/mappings/os-v2/names/name-v2.0.0.json
@@ -9,11 +9,34 @@
         }
       },
       "analyzer": {
+        "accent_edge_analyzer": {
+          "tokenizer": "standard",
+          "type": "custom",
+          "char_filter": ["strip_special_chars"],
+          "filter": [
+            "lowercase",
+            "asciifolding",
+            "edgegrams"
+          ]
+        },
         "accent_analyzer": {
           "tokenizer": "standard",
           "type": "custom",
           "char_filter": ["strip_special_chars"],
-          "filter": ["lowercase", "asciifolding"]
+          "filter": [
+            "lowercase",
+            "asciifolding"
+          ]
+        }
+      },
+      "normalizer": {
+        "accent_normalizer": {
+          "type": "custom",
+          "char_filter": ["strip_special_chars"],
+          "filter": [
+            "lowercase",
+            "asciifolding"
+          ]
         }
       },
       "filter": {
@@ -24,6 +47,11 @@
         "asciifolding": {
           "type": "asciifolding",
           "preserve_original": true
+        },
+        "edgegrams": {
+          "type": "edge_ngram",
+          "min_gram": 2,
+          "max_gram": 20
         }
       }
     }
@@ -61,26 +89,14 @@
       },
       "name": {
         "type": "text",
-        "analyzer": "accent_analyzer",
+        "analyzer": "accent_edge_analyzer",
         "search_analyzer": "accent_analyzer",
-        "copy_to": "name_sort",
-        "fields": {
-          "suggest": {
-            "type": "search_as_you_type",
-            "analyzer": "accent_analyzer",
-            "search_analyzer": "accent_analyzer"
-          }
-        }
+        "copy_to": "name_sort"
       },
       "given_name": {
         "type": "text",
-        "fields": {
-          "suggest": {
-            "type": "search_as_you_type",
-            "analyzer": "accent_analyzer",
-            "search_analyzer": "accent_analyzer"
-          }
-        }
+        "analyzer": "accent_edge_analyzer",
+        "search_analyzer": "accent_analyzer"
       },
       "family_name": {
         "type": "text"
@@ -89,11 +105,7 @@
         "properties": {
           "identifier": {
             "type": "keyword",
-            "fields": {
-              "suggest": {
-                "type": "search_as_you_type"
-              }
-            }
+            "normalizer": "accent_normalizer"
           },
           "scheme": {
             "type": "keyword"
@@ -110,12 +122,9 @@
             "type": "keyword"
           },
           "name": {
-            "type": "keyword",
-            "fields": {
-              "suggest": {
-                "type": "search_as_you_type"
-              }
-            }
+            "type": "text",
+            "analyzer": "accent_edge_analyzer",
+            "search_analyzer": "accent_analyzer"
           }
         }
       },

--- a/invenio_vocabularies/contrib/names/mappings/os-v2/names/name-v2.0.0.json
+++ b/invenio_vocabularies/contrib/names/mappings/os-v2/names/name-v2.0.0.json
@@ -1,0 +1,131 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "$schema": {
+        "type": "keyword",
+        "index": "false"
+      },
+      "created": {
+        "type": "date"
+      },
+      "updated": {
+        "type": "date"
+      },
+      "indexed_at": {
+        "type": "date"
+      },
+      "uuid": {
+        "type": "keyword"
+      },
+      "version_id": {
+        "type": "integer"
+      },
+      "id": {
+        "type": "keyword"
+      },
+      "tags": {
+        "type": "keyword"
+      },
+      "name_sort": {
+        "type": "keyword"
+      },
+      "name": {
+        "type": "text",
+        "analyzer": "accent_analyzer",
+        "search_analyzer": "accent_analyzer",
+        "copy_to": "name_sort",
+        "fields": {
+          "suggest": {
+            "type": "search_as_you_type",
+            "analyzer": "accent_analyzer",
+            "search_analyzer": "accent_analyzer"
+          }
+        }
+      },
+      "given_name": {
+        "type": "text",
+        "fields": {
+          "suggest": {
+            "type": "search_as_you_type",
+            "analyzer": "accent_analyzer",
+            "search_analyzer": "accent_analyzer"
+          }
+        }
+      },
+      "family_name": {
+        "type": "text"
+      },
+      "identifiers": {
+        "properties": {
+          "identifier": {
+            "type": "keyword",
+            "fields": {
+              "suggest": {
+                "type": "search_as_you_type"
+              }
+            }
+          },
+          "scheme": {
+            "type": "keyword"
+          }
+        }
+      },
+      "affiliations": {
+        "type": "object",
+        "properties": {
+          "@v": {
+            "type": "keyword"
+          },
+          "id": {
+            "type": "keyword"
+          },
+          "name": {
+            "type": "keyword",
+            "fields": {
+              "suggest": {
+                "type": "search_as_you_type"
+              }
+            }
+          }
+        }
+      },
+      "pid": {
+        "type": "object",
+        "properties": {
+          "pk": {
+            "type": "integer"
+          },
+          "pid_type": {
+            "type": "keyword"
+          },
+          "obj_type": {
+            "type": "keyword"
+          },
+          "status": {
+            "type": "keyword"
+          }
+        }
+      }
+    }
+  },
+  "settings": {
+    "analysis": {
+      "char_filter": {
+        "strip_special_chars": {
+          "type": "pattern_replace",
+          "pattern": "[\\p{Punct}\\p{S}]",
+          "replacement": ""
+        }
+      },
+      "analyzer": {
+        "accent_analyzer": {
+          "tokenizer": "standard",
+          "type": "custom",
+          "char_filter": ["strip_special_chars"],
+          "filter": ["lowercase", "asciifolding"]
+        }
+      }
+    }
+  }
+}

--- a/invenio_vocabularies/contrib/names/mappings/os-v2/names/name-v2.0.0.json
+++ b/invenio_vocabularies/contrib/names/mappings/os-v2/names/name-v2.0.0.json
@@ -1,4 +1,33 @@
 {
+  "settings": {
+    "analysis": {
+      "char_filter": {
+        "strip_special_chars": {
+          "type": "pattern_replace",
+          "pattern": "[\\p{Punct}\\p{S}]",
+          "replacement": ""
+        }
+      },
+      "analyzer": {
+        "accent_analyzer": {
+          "tokenizer": "standard",
+          "type": "custom",
+          "char_filter": ["strip_special_chars"],
+          "filter": ["lowercase", "asciifolding"]
+        }
+      },
+      "filter": {
+        "lowercase": {
+          "type": "lowercase",
+          "preserve_original": true
+        },
+        "asciifolding": {
+          "type": "asciifolding",
+          "preserve_original": true
+        }
+      }
+    }
+  },
   "mappings": {
     "dynamic": "strict",
     "properties": {
@@ -105,35 +134,6 @@
           "status": {
             "type": "keyword"
           }
-        }
-      }
-    }
-  },
-  "settings": {
-    "analysis": {
-      "char_filter": {
-        "strip_special_chars": {
-          "type": "pattern_replace",
-          "pattern": "[\\p{Punct}\\p{S}]",
-          "replacement": ""
-        }
-      },
-      "analyzer": {
-        "accent_analyzer": {
-          "tokenizer": "standard",
-          "type": "custom",
-          "char_filter": ["strip_special_chars"],
-          "filter": ["lowercase", "asciifolding"]
-        }
-      },
-      "filter": {
-        "lowercase": {
-          "type": "lowercase",
-          "preserve_original": true
-        },
-        "asciifolding": {
-          "type": "asciifolding",
-          "preserve_original": true
         }
       }
     }

--- a/invenio_vocabularies/contrib/names/names.py
+++ b/invenio_vocabularies/contrib/names/names.py
@@ -45,8 +45,9 @@ record_type = RecordTypeFactory(
         # service level when create({}), see records-resources.
         "pid": db.Column(db.String(255), unique=True),
     },
-    schema_version="2.0.0",
+    schema_version="1.0.0",
     schema_path="local://names/name-v1.0.0.json",
+    index_name="names-name-v2.0.0",
     record_relations=name_relations,
     record_dumper=SearchDumper(
         model_fields={"pid": ("id", str)},

--- a/invenio_vocabularies/contrib/names/names.py
+++ b/invenio_vocabularies/contrib/names/names.py
@@ -45,7 +45,7 @@ record_type = RecordTypeFactory(
         # service level when create({}), see records-resources.
         "pid": db.Column(db.String(255), unique=True),
     },
-    schema_version="1.0.0",
+    schema_version="2.0.0",
     schema_path="local://names/name-v1.0.0.json",
     record_relations=name_relations,
     record_dumper=SearchDumper(

--- a/tests/contrib/names/test_names_datastreams.py
+++ b/tests/contrib/names/test_names_datastreams.py
@@ -32,6 +32,7 @@ def name_full_data():
         "id": "0000-0001-8135-3489",
         "given_name": "Lars Holm",
         "family_name": "Nielsen",
+        "name": "Nielsen, Lars Holm",
         "identifiers": [
             {
                 "scheme": "orcid",
@@ -174,6 +175,7 @@ def test_names_service_writer_update_existing(app, db, search_clear, name_full_d
     updated_name = deepcopy(name_full_data)
     updated_name["given_name"] = "Pablo"
     updated_name["family_name"] = "Panero"
+    updated_name["name"] = "Panero, Pablo"
     # check changes vocabulary
     _ = writer.write(stream_entry=StreamEntry(updated_name))
     service = current_service_registry.get("names")
@@ -193,6 +195,7 @@ def test_names_service_writer_update_non_existing(
     updated_name
     updated_name["given_name"] = "Pablo"
     updated_name["family_name"] = "Panero"
+    updated_name["name"] = "Panero, Pablo"
     # check changes vocabulary
     writer = NamesServiceWriter(update=True)
     name = writer.write(stream_entry=StreamEntry(updated_name))

--- a/tests/contrib/names/test_names_resource.py
+++ b/tests/contrib/names/test_names_resource.py
@@ -29,9 +29,9 @@ def names_data():
     return [
         {
             "id": "0000-0001-8135-3489",
-            "given_name": "Lars Holm",
-            "family_name": "Nielsen",
-            "name": "Nielsen, Lars Holm",
+            "given_name": "Niels John",
+            "family_name": "Davidson",
+            "name": "Davidson, Niels John",
             "identifiers": [
                 {
                     "scheme": "orcid",
@@ -42,9 +42,9 @@ def names_data():
         },
         {
             "id": "0000-0002-8438-3752",
-            "given_name": "Säksham",
-            "family_name": "Arœra",
-            "name": "Arœra, Säksham",
+            "given_name": "Dwäyne",
+            "family_name": "Johnsœn",
+            "name": "Johnsœn, Dwäyne",
             "identifiers": [
                 {
                     "scheme": "orcid",
@@ -55,16 +55,16 @@ def names_data():
         },
         {
             "id": "0000-0002-0816-7126",
-            "given_name": "Jose Benito",
-            "family_name": "Gonzalez Lopez",
-            "name": "Gonzalez Lopez, Jose Benito",
+            "given_name": "John",
+            "family_name": "Cena",
+            "name": "Cena, John",
             "identifiers": [
                 {
                     "scheme": "orcid",
                     "identifier": "0000-0002-0816-7126",
                 }
             ],
-            "affiliations": [{"name": "CERN"}],
+            "affiliations": [{"name": "WWE"}],
         },
     ]
 
@@ -150,20 +150,27 @@ def test_names_suggest_sort(client, example_multiple_names, h, prefix):
     """Test a successful search."""
 
     # With typo
-    res = client.get(f"{prefix}?suggest=lsrs%20holm", headers=h)  # lsrs holm
-    print(res.data)
+    res = client.get(f"{prefix}?suggest=davisson", headers=h)
     assert res.status_code == 200
     assert res.json["hits"]["total"] == 1
-    assert res.json["hits"]["hits"][0]["name"] == "Nielsen, Lars Holm"
+    assert res.json["hits"]["hits"][0]["name"] == "Davidson, Niels John"
 
     # With accent
-    res = client.get(f"{prefix}?suggest=saksham", headers=h)
+    res = client.get(f"{prefix}?suggest=dwayne", headers=h)
     assert res.status_code == 200
     assert res.json["hits"]["total"] == 1
-    assert res.json["hits"]["hits"][0]["name"] == "Arœra, Säksham"
+    assert res.json["hits"]["hits"][0]["name"] == "Johnsœn, Dwäyne"
 
     # With incomplete
-    res = client.get(f"{prefix}?suggest=jos", headers=h)  # jos
+    res = client.get(f"{prefix}?suggest=joh", headers=h)
     assert res.status_code == 200
-    assert res.json["hits"]["total"] == 1
-    assert res.json["hits"]["hits"][0]["name"] == "Gonzalez Lopez, Jose Benito"
+    assert res.json["hits"]["total"] == 3
+
+    # With affiliation
+    res = client.get(f"{prefix}?suggest=john%20wwe", headers=h)
+    assert res.status_code == 200
+    assert (
+        res.json["hits"]["total"] == 3
+    )  # Will find 3 johns but WWE affiliation should be at the top
+    assert res.json["hits"]["hits"][0]["name"] == "Cena, John"
+    assert res.json["hits"]["hits"][0]["affiliations"][0]["name"] == "WWE"

--- a/tests/contrib/names/test_names_resource.py
+++ b/tests/contrib/names/test_names_resource.py
@@ -161,6 +161,11 @@ def test_names_suggest_sort(client, example_multiple_names, h, prefix):
     assert res.json["hits"]["total"] == 1
     assert res.json["hits"]["hits"][0]["name"] == "Johnsœn, Dwäyne"
 
+    res = client.get(f"{prefix}?suggest=Dw%C3%A4yne", headers=h)  # Dwäyne
+    assert res.status_code == 200
+    assert res.json["hits"]["total"] == 1
+    assert res.json["hits"]["hits"][0]["name"] == "Johnsœn, Dwäyne"
+
     # With incomplete
     res = client.get(f"{prefix}?suggest=joh", headers=h)
     assert res.status_code == 200

--- a/tests/contrib/names/test_names_resource.py
+++ b/tests/contrib/names/test_names_resource.py
@@ -85,3 +85,19 @@ def test_names_resolve(client, example_name, h, prefix):
 
     res = client.get(f"{prefix}/orcid/0000-0002-5082-6404", headers=h)
     assert res.status_code == 404
+
+
+def test_names_suggest_sort(client, example_name, h, prefix):
+    """Test a successful search."""
+
+    # With typo
+    res = client.get(f"{prefix}?suggest=lsrs holm", headers=h)
+    assert res.status_code == 200
+    assert res.json["hits"]["total"] == 1
+    assert res.json["hits"]["hits"][0]["name"] == "Nielsen, Lars Holm"
+
+    # With accent
+    res = client.get(f"{prefix}?suggest=níelsën", headers=h)
+    assert res.status_code == 200
+    assert res.json["hits"]["total"] == 1
+    assert res.json["hits"]["hits"][0]["name"] == "Nielsen, Lars Holm"


### PR DESCRIPTION
Fixes: https://github.com/inveniosoftware/invenio-app-rdm/issues/2756

The names in the database and index are inverted, therefore the suggest API first tries to search on the last name and prioritizes that due to how edge ngram works for the suggest API.
This solution add suggest API for given name for better results.

# ATTENTION

tests fail due to https://github.com/inveniosoftware/invenio-vocabularies/pull/372, to be rebased and merged after #372