### PR TITLE
Affiliations OpenAIRE OpenOrgs PIC

### DIFF
--- a/invenio_vocabularies/cli.py
+++ b/invenio_vocabularies/cli.py
@@ -101,9 +101,14 @@ def update(vocabulary, filepath=None, origin=None):
 
     for w_conf in config["writers"]:
         if w_conf["type"] == "async":
-            w_conf["args"]["writer"]["args"]["update"] = True
+            w_conf_update = w_conf["args"]["writer"]
         else:
-            w_conf["args"]["update"] = True
+            w_conf_update = w_conf
+
+        if "args" in w_conf_update:
+            w_conf_update["args"]["update"] = True
+        else:
+            w_conf_update["args"] = {"update": True}
 
     success, errored, filtered = _process_vocab(config)
 

--- a/invenio_vocabularies/config.py
+++ b/invenio_vocabularies/config.py
@@ -43,8 +43,17 @@ VOCABULARIES_IDENTIFIER_SCHEMES = {
 }
 """"Generic identifier schemes, usable by other vocabularies."""
 
+
+def is_pic(val):
+    """Test if argument is a Participant Identification Code (PIC)."""
+    if len(val) != 9:
+        return False
+    return val.isdigit()
+
+
 VOCABULARIES_AFFILIATION_SCHEMES = {
     **VOCABULARIES_IDENTIFIER_SCHEMES,
+    "pic": {"label": _("PIC"), "validator": is_pic},
 }
 """Affiliations allowed identifier schemes."""
 

--- a/invenio_vocabularies/contrib/awards/datastreams.py
+++ b/invenio_vocabularies/contrib/awards/datastreams.py
@@ -8,71 +8,13 @@
 
 """Awards datastreams, transformers, writers and readers."""
 
-import io
-
-import requests
 from invenio_access.permissions import system_identity
 from invenio_i18n import lazy_gettext as _
 
-from ...datastreams.errors import ReaderError, TransformerError
-from ...datastreams.readers import BaseReader
+from ...datastreams.errors import TransformerError
 from ...datastreams.transformers import BaseTransformer
 from ...datastreams.writers import ServiceWriter
 from .config import awards_ec_ror_id, awards_openaire_funders_mapping
-
-
-class OpenAIREProjectHTTPReader(BaseReader):
-    """OpenAIRE Project HTTP Reader returning an in-memory binary stream of the latest OpenAIRE Graph Dataset project tar file."""
-
-    def _iter(self, fp, *args, **kwargs):
-        raise NotImplementedError(
-            "OpenAIREProjectHTTPReader downloads one file and therefore does not iterate through items"
-        )
-
-    def read(self, item=None, *args, **kwargs):
-        """Reads the latest OpenAIRE Graph Dataset project tar file from Zenodo and yields an in-memory binary stream of it."""
-        if item:
-            raise NotImplementedError(
-                "OpenAIREProjectHTTPReader does not support being chained after another reader"
-            )
-
-        if self._origin == "full":
-            # OpenAIRE Graph Dataset
-            api_url = "https://zenodo.org/api/records/3516917"
-        elif self._origin == "diff":
-            # OpenAIRE Graph dataset: new collected projects
-            api_url = "https://zenodo.org/api/records/6419021"
-        else:
-            raise ReaderError("The --origin option should be either 'full' or 'diff'")
-
-        # Call the signposting `linkset+json` endpoint for the Concept DOI (i.e. latest version) of the OpenAIRE Graph Dataset.
-        # See: https://github.com/inveniosoftware/rfcs/blob/master/rfcs/rdm-0071-signposting.md#provide-an-applicationlinksetjson-endpoint
-        headers = {"Accept": "application/linkset+json"}
-        api_resp = requests.get(api_url, headers=headers)
-        api_resp.raise_for_status()
-
-        # Extract the Landing page Link Set Object located as the first (index 0) item.
-        landing_page_linkset = api_resp.json()["linkset"][0]
-
-        # Extract the URL of the only project tar file linked to the record.
-        landing_page_project_tar_items = [
-            item
-            for item in landing_page_linkset["item"]
-            if item["type"] == "application/x-tar"
-            and item["href"].endswith("/project.tar")
-        ]
-        if len(landing_page_project_tar_items) != 1:
-            raise ReaderError(
-                f"Expected 1 project tar item but got {len(landing_page_project_tar_items)}"
-            )
-        file_url = landing_page_project_tar_items[0]["href"]
-
-        # Download the project tar file and fully load the response bytes content in memory.
-        # The bytes content are then wrapped by a BytesIO to be file-like object (as required by `tarfile.open`).
-        # Using directly `file_resp.raw` is not possible since `tarfile.open` requires the file-like object to be seekable.
-        file_resp = requests.get(file_url)
-        file_resp.raise_for_status()
-        yield io.BytesIO(file_resp.content)
 
 
 class AwardsServiceWriter(ServiceWriter):
@@ -172,9 +114,7 @@ class OpenAIREProjectTransformer(BaseTransformer):
         return stream_entry
 
 
-VOCABULARIES_DATASTREAM_READERS = {
-    "openaire-project-http": OpenAIREProjectHTTPReader,
-}
+VOCABULARIES_DATASTREAM_READERS = {}
 
 VOCABULARIES_DATASTREAM_TRANSFORMERS = {
     "openaire-award": OpenAIREProjectTransformer,

--- a/invenio_vocabularies/contrib/common/openaire/__init__.py
+++ b/invenio_vocabularies/contrib/common/openaire/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""OpenAIRE-related module."""

--- a/invenio_vocabularies/contrib/common/openaire/datastreams.py
+++ b/invenio_vocabularies/contrib/common/openaire/datastreams.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""OpenAIRE-related Datastreams Readers/Writers/Transformers module."""
+
+import io
+
+import requests
+
+from invenio_vocabularies.datastreams.errors import ReaderError
+from invenio_vocabularies.datastreams.readers import BaseReader
+
+
+class OpenAIREHTTPReader(BaseReader):
+    """OpenAIRE HTTP Reader returning an in-memory binary stream of the latest OpenAIRE Graph Dataset tar file of a given type."""
+
+    def __init__(self, origin=None, mode="r", tar_href=None, *args, **kwargs):
+        """Constructor."""
+        self.tar_href = tar_href
+        super().__init__(origin, mode, *args, **kwargs)
+
+    def _iter(self, fp, *args, **kwargs):
+        raise NotImplementedError(
+            "OpenAIREHTTPReader downloads one file and therefore does not iterate through items"
+        )
+
+    def read(self, item=None, *args, **kwargs):
+        """Reads the latest OpenAIRE Graph Dataset tar file of a given type from Zenodo and yields an in-memory binary stream of it."""
+        if item:
+            raise NotImplementedError(
+                "OpenAIREHTTPReader does not support being chained after another reader"
+            )
+
+        if self._origin == "full":
+            # OpenAIRE Graph Dataset
+            api_url = "https://zenodo.org/api/records/3516917"
+        elif self._origin == "diff":
+            # OpenAIRE Graph dataset: new collected projects
+            api_url = "https://zenodo.org/api/records/6419021"
+        else:
+            raise ReaderError("The --origin option should be either 'full' or 'diff'")
+
+        # Call the signposting `linkset+json` endpoint for the Concept DOI (i.e. latest version) of the OpenAIRE Graph Dataset.
+        # See: https://github.com/inveniosoftware/rfcs/blob/master/rfcs/rdm-0071-signposting.md#provide-an-applicationlinksetjson-endpoint
+        headers = {"Accept": "application/linkset+json"}
+        api_resp = requests.get(api_url, headers=headers)
+        api_resp.raise_for_status()
+
+        # Extract the Landing page Link Set Object located as the first (index 0) item.
+        landing_page_linkset = api_resp.json()["linkset"][0]
+
+        # Extract the URL of the only tar file matching `tar_href` linked to the record.
+        landing_page_matching_tar_items = [
+            item
+            for item in landing_page_linkset["item"]
+            if item["type"] == "application/x-tar"
+            and item["href"].endswith(self.tar_href)
+        ]
+        if len(landing_page_matching_tar_items) != 1:
+            raise ReaderError(
+                f"Expected 1 tar item matching {self.tar_href} but got {len(landing_page_matching_tar_items)}"
+            )
+        file_url = landing_page_matching_tar_items[0]["href"]
+
+        # Download the matching tar file and fully load the response bytes content in memory.
+        # The bytes content are then wrapped by a BytesIO to be file-like object (as required by `tarfile.open`).
+        # Using directly `file_resp.raw` is not possible since `tarfile.open` requires the file-like object to be seekable.
+        file_resp = requests.get(file_url)
+        file_resp.raise_for_status()
+        yield io.BytesIO(file_resp.content)
+
+
+VOCABULARIES_DATASTREAM_READERS = {
+    "openaire-http": OpenAIREHTTPReader,
+}
+
+VOCABULARIES_DATASTREAM_TRANSFORMERS = {}
+
+VOCABULARIES_DATASTREAM_WRITERS = {}

--- a/invenio_vocabularies/datastreams/writers.py
+++ b/invenio_vocabularies/datastreams/writers.py
@@ -87,7 +87,23 @@ class ServiceWriter(BaseWriter):
     def _do_update(self, entry):
         vocab_id = self._entry_id(entry)
         current = self._resolve(vocab_id)
-        updated = dict(current.to_dict(), **entry)
+
+        # Merge the `current` dictionary with new data in the `entry` dictionary
+        # by appending to lists at the top level instead of overwriting the list.
+        updated = current.to_dict()
+        for key, value in entry.items():
+            if (
+                key in updated
+                and isinstance(updated[key], list)
+                and isinstance(value, list)
+            ):
+                for value_item in value:
+                    # TODO: If an identifier was wrong and is then corrected, this will cause duplicated entries.
+                    if value_item not in updated[key]:
+                        updated[key].append(value_item)
+            else:
+                updated[key] = value
+
         return StreamEntry(self._service.update(self._identity, vocab_id, updated))
 
     def write(self, stream_entry, *args, **kwargs):

--- a/invenio_vocabularies/factories.py
+++ b/invenio_vocabularies/factories.py
@@ -16,6 +16,9 @@ from invenio_records_resources.proxies import current_service_registry
 from .contrib.affiliations.datastreams import (
     DATASTREAM_CONFIG as affiliations_ds_config,
 )
+from .contrib.affiliations.datastreams import (
+    DATASTREAM_CONFIG_OPENAIRE as affiliations_openaire_ds_config,
+)
 from .contrib.awards.datastreams import DATASTREAM_CONFIG as awards_ds_config
 from .contrib.funders.datastreams import DATASTREAM_CONFIG as funders_ds_config
 from .contrib.names.datastreams import DATASTREAM_CONFIG as names_ds_config
@@ -95,6 +98,17 @@ class AffiliationsVocabularyConfig(VocabularyConfig):
         raise NotImplementedError("Service not implemented for Affiliations")
 
 
+class AffiliationsOpenAIREVocabularyConfig(VocabularyConfig):
+    """OpenAIRE Affiliations Vocabulary Config."""
+
+    config = affiliations_openaire_ds_config
+    vocabulary_name = "affiliations:openaire"
+
+    def get_service(self):
+        """Get the service for the vocabulary."""
+        raise NotImplementedError("Service not implemented for OpenAIRE Affiliations")
+
+
 def get_vocabulary_config(vocabulary):
     """Factory function to get the appropriate Vocabulary Config."""
     vocab_config = {
@@ -102,6 +116,7 @@ def get_vocabulary_config(vocabulary):
         "funders": FundersVocabularyConfig,
         "awards": AwardsVocabularyConfig,
         "affiliations": AffiliationsVocabularyConfig,
+        "affiliations:openaire": AffiliationsOpenAIREVocabularyConfig,
         "subjects": SubjectsVocabularyConfig,
     }
     return vocab_config.get(vocabulary, VocabularyConfig)()

--- a/tests/contrib/affiliations/conftest.py
+++ b/tests/contrib/affiliations/conftest.py
@@ -33,6 +33,16 @@ def affiliation_full_data():
     }
 
 
+@pytest.fixture(scope="function")
+def openaire_affiliation_full_data():
+    """Full OpenAIRE affiliation data."""
+    return {
+        "openaire_id": "openorgs____::47efb6602225236c0b207761a8b3a21c",
+        "id": "01ggx4157",
+        "identifiers": [{"identifier": "999988133", "scheme": "pic"}],
+    }
+
+
 @pytest.fixture(scope="module")
 def service():
     """Affiliations service object."""

--- a/tests/contrib/awards/test_awards_datastreams.py
+++ b/tests/contrib/awards/test_awards_datastreams.py
@@ -8,9 +8,7 @@
 
 """Awards datastreams tests."""
 
-import io
 from copy import deepcopy
-from unittest.mock import patch
 
 import pytest
 from invenio_access.permissions import system_identity
@@ -18,11 +16,10 @@ from invenio_access.permissions import system_identity
 from invenio_vocabularies.contrib.awards.api import Award
 from invenio_vocabularies.contrib.awards.datastreams import (
     AwardsServiceWriter,
-    OpenAIREProjectHTTPReader,
     OpenAIREProjectTransformer,
 )
 from invenio_vocabularies.datastreams import StreamEntry
-from invenio_vocabularies.datastreams.errors import ReaderError, WriterError
+from invenio_vocabularies.datastreams.errors import WriterError
 
 
 @pytest.fixture(scope="function")
@@ -113,126 +110,6 @@ def expected_from_award_json_ec():
         "acronym": "TS",
         "program": "test",
     }
-
-
-API_JSON_RESPONSE_CONTENT = {
-    "linkset": [
-        {
-            "anchor": "https://example.com/records/10488385",
-            "item": [
-                {
-                    "href": "https://example.com/records/10488385/files/organization.tar",
-                    "type": "application/x-tar",
-                },
-                {
-                    "href": "https://example.com/records/10488385/files/project.tar",
-                    "type": "application/x-tar",
-                },
-            ],
-        },
-        {
-            "anchor": "https://example.com/api/records/10488385",
-            "describes": [
-                {"href": "https://example.com/records/10488385", "type": "text/html"}
-            ],
-            "type": "application/dcat+xml",
-        },
-    ]
-}
-
-API_JSON_RESPONSE_CONTENT_WRONG_NUMBER_PROJECT_TAR_ITEMS_ERROR = {
-    "linkset": [
-        {
-            "anchor": "https://example.com/records/10488385",
-            "item": [
-                {
-                    "href": "https://example.com/records/10488385/files/organization.tar",
-                    "type": "application/x-tar",
-                },
-                {
-                    "href": "https://example.com/records/10488385/files/project.tar",
-                    "type": "application/x-tar",
-                },
-                {
-                    "href": "https://example.com/another/project.tar",
-                    "type": "application/x-tar",
-                },
-            ],
-        },
-        {
-            "anchor": "https://example.com/api/records/10488385",
-            "describes": [
-                {"href": "https://example.com/records/10488385", "type": "text/html"}
-            ],
-            "type": "application/dcat+xml",
-        },
-    ]
-}
-
-DOWNLOAD_FILE_BYTES_CONTENT = b"The content of the file"
-
-
-class MockResponse:
-    content = DOWNLOAD_FILE_BYTES_CONTENT
-
-    def __init__(self, api_json_response_content):
-        self.api_json_response_content = api_json_response_content
-
-    def json(self, **kwargs):
-        return self.api_json_response_content
-
-    def raise_for_status(self):
-        pass
-
-
-@pytest.fixture(scope="function")
-def download_file_bytes_content():
-    return DOWNLOAD_FILE_BYTES_CONTENT
-
-
-@patch(
-    "requests.get",
-    side_effect=lambda url, headers=None: MockResponse(API_JSON_RESPONSE_CONTENT),
-)
-def test_openaire_project_http_reader(_, download_file_bytes_content):
-    reader = OpenAIREProjectHTTPReader(origin="full")
-    results = []
-    for entry in reader.read():
-        results.append(entry)
-
-    assert len(results) == 1
-    assert isinstance(results[0], io.BytesIO)
-    assert results[0].read() == download_file_bytes_content
-
-
-@patch(
-    "requests.get",
-    side_effect=lambda url, headers=None: MockResponse(
-        API_JSON_RESPONSE_CONTENT_WRONG_NUMBER_PROJECT_TAR_ITEMS_ERROR
-    ),
-)
-def test_openaire_project_http_reader_wrong_number_tar_items_error(_):
-    reader = OpenAIREProjectHTTPReader(origin="full")
-    with pytest.raises(ReaderError):
-        next(reader.read())
-
-
-def test_openaire_project_http_reader_unsupported_origin_option():
-    reader = OpenAIREProjectHTTPReader(origin="unsupported_origin_option")
-    with pytest.raises(ReaderError):
-        next(reader.read())
-
-
-def test_openaire_project_http_reader_item_not_implemented():
-    reader = OpenAIREProjectHTTPReader()
-    with pytest.raises(NotImplementedError):
-        next(reader.read("A fake item"))
-
-
-def test_openaire_project_http_reader_iter_not_implemented():
-    reader = OpenAIREProjectHTTPReader()
-    with pytest.raises(NotImplementedError):
-        reader._iter("A fake file pointer")
 
 
 def test_awards_transformer(app, dict_award_entry, expected_from_award_json):

--- a/tests/contrib/common/openaire/test_openaire_datastreams.py
+++ b/tests/contrib/common/openaire/test_openaire_datastreams.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""OpenAIRE-related Datastreams Readers/Writers/Transformers tests."""
+
+import io
+from unittest.mock import patch
+
+import pytest
+
+from invenio_vocabularies.contrib.common.openaire.datastreams import OpenAIREHTTPReader
+from invenio_vocabularies.datastreams.errors import ReaderError
+
+API_JSON_RESPONSE_CONTENT = {
+    "linkset": [
+        {
+            "anchor": "https://example.com/records/10488385",
+            "item": [
+                {
+                    "href": "https://example.com/records/10488385/files/organization.tar",
+                    "type": "application/x-tar",
+                },
+                {
+                    "href": "https://example.com/records/10488385/files/project.tar",
+                    "type": "application/x-tar",
+                },
+            ],
+        },
+        {
+            "anchor": "https://example.com/api/records/10488385",
+            "describes": [
+                {"href": "https://example.com/records/10488385", "type": "text/html"}
+            ],
+            "type": "application/dcat+xml",
+        },
+    ]
+}
+
+API_JSON_RESPONSE_CONTENT_WRONG_NUMBER_PROJECT_TAR_ITEMS_ERROR = {
+    "linkset": [
+        {
+            "anchor": "https://example.com/records/10488385",
+            "item": [
+                {
+                    "href": "https://example.com/records/10488385/files/organization.tar",
+                    "type": "application/x-tar",
+                },
+                {
+                    "href": "https://example.com/records/10488385/files/project.tar",
+                    "type": "application/x-tar",
+                },
+                {
+                    "href": "https://example.com/another/project.tar",
+                    "type": "application/x-tar",
+                },
+            ],
+        },
+        {
+            "anchor": "https://example.com/api/records/10488385",
+            "describes": [
+                {"href": "https://example.com/records/10488385", "type": "text/html"}
+            ],
+            "type": "application/dcat+xml",
+        },
+    ]
+}
+
+DOWNLOAD_FILE_BYTES_CONTENT = b"The content of the file"
+
+
+class MockResponse:
+    content = DOWNLOAD_FILE_BYTES_CONTENT
+
+    def __init__(self, api_json_response_content):
+        self.api_json_response_content = api_json_response_content
+
+    def json(self, **kwargs):
+        return self.api_json_response_content
+
+    def raise_for_status(self):
+        pass
+
+
+@pytest.fixture(scope="function")
+def download_file_bytes_content():
+    return DOWNLOAD_FILE_BYTES_CONTENT
+
+
+@patch(
+    "requests.get",
+    side_effect=lambda url, headers=None: MockResponse(API_JSON_RESPONSE_CONTENT),
+)
+def test_openaire_http_reader(_, download_file_bytes_content):
+    reader = OpenAIREHTTPReader(origin="full", tar_href="/project.tar")
+    results = []
+    for entry in reader.read():
+        results.append(entry)
+
+    assert len(results) == 1
+    assert isinstance(results[0], io.BytesIO)
+    assert results[0].read() == download_file_bytes_content
+
+
+@patch(
+    "requests.get",
+    side_effect=lambda url, headers=None: MockResponse(
+        API_JSON_RESPONSE_CONTENT_WRONG_NUMBER_PROJECT_TAR_ITEMS_ERROR
+    ),
+)
+def test_openaire_http_reader_wrong_number_tar_items_error(_):
+    reader = OpenAIREHTTPReader(origin="full", tar_href="/project.tar")
+    with pytest.raises(ReaderError):
+        next(reader.read())
+
+
+def test_openaire_http_reader_unsupported_origin_option():
+    reader = OpenAIREHTTPReader(origin="unsupported_origin_option")
+    with pytest.raises(ReaderError):
+        next(reader.read())
+
+
+def test_openaire_http_reader_item_not_implemented():
+    reader = OpenAIREHTTPReader()
+    with pytest.raises(NotImplementedError):
+        next(reader.read("A fake item"))
+
+
+def test_openaire_http_reader_iter_not_implemented():
+    reader = OpenAIREHTTPReader()
+    with pytest.raises(NotImplementedError):
+        reader._iter("A fake file pointer")

--- a/tests/datastreams/test_writers.py
+++ b/tests/datastreams/test_writers.py
@@ -76,6 +76,28 @@ def test_service_writer_update_non_existing(lang_type, lang_data, service, ident
     assert dict(record, **updated_lang) == record
 
 
+def test_writer_wrong_config_no_insert_no_update(
+    lang_type, lang_data, service, identity
+):
+    writer = ServiceWriter(service, identity=identity, insert=False, update=False)
+
+    with pytest.raises(WriterError) as err:
+        writer.write(stream_entry=StreamEntry(lang_data))
+
+    expected_error = ["Writer wrongly configured to not insert and to not update"]
+    assert expected_error in err.value.args
+
+
+def test_writer_no_insert(lang_type, lang_data, service, identity):
+    writer = ServiceWriter(service, identity=identity, insert=False, update=True)
+
+    with pytest.raises(WriterError) as err:
+        writer.write(stream_entry=StreamEntry(lang_data))
+
+    expected_error = [f"Vocabulary entry does not exist: {lang_data}"]
+    assert expected_error in err.value.args
+
+
 ##
 # YAML Writer
 ##


### PR DESCRIPTION
:heart: Thank you for your contribution!

Closes #393

### Description

**Recommended to be reviewed commit by commit.**

This Pull Request configures a datastream which "augments" the existing affiliations vocabulary by adding the Participant Identification Code (PIC) based on data coming from OpenAIRE Graph Dataset (which is based on OpenAIRE's OpenOrgs data).

Updating existing affiliations can be achieved by running:

```bash
invenio vocabularies update -v affiliations:openaire -o full
```

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
