### PR TITLE
Rename patched filters so the normalizer uses the default ones

### DIFF
--- a/invenio_vocabularies/contrib/funders/mappings/os-v1/funders/funder-v2.0.0.json
+++ b/invenio_vocabularies/contrib/funders/mappings/os-v1/funders/funder-v2.0.0.json
@@ -14,8 +14,8 @@
           "type": "custom",
           "char_filter": ["strip_special_chars"],
           "filter": [
-            "lowercase",
-            "asciifolding",
+            "rdm_lowercase",
+            "rdm_asciifolding",
             "edgegrams"
           ]
         },
@@ -24,8 +24,8 @@
           "type": "custom",
           "char_filter": ["strip_special_chars"],
           "filter": [
-            "lowercase",
-            "asciifolding"
+            "rdm_lowercase",
+            "rdm_asciifolding"
           ]
         }
       },
@@ -40,11 +40,11 @@
         }
       },
       "filter": {
-        "lowercase": {
+        "rdm_lowercase": {
           "type": "lowercase",
           "preserve_original": true
         },
-        "asciifolding": {
+        "rdm_asciifolding": {
           "type": "asciifolding",
           "preserve_original": true
         },

--- a/invenio_vocabularies/contrib/funders/mappings/os-v1/funders/funder-v2.0.0.json
+++ b/invenio_vocabularies/contrib/funders/mappings/os-v1/funders/funder-v2.0.0.json
@@ -14,8 +14,8 @@
           "type": "custom",
           "char_filter": ["strip_special_chars"],
           "filter": [
-            "rdm_lowercase",
-            "rdm_asciifolding",
+            "lowercasepreserveoriginal",
+            "asciifoldingpreserveoriginal",
             "edgegrams"
           ]
         },
@@ -24,8 +24,8 @@
           "type": "custom",
           "char_filter": ["strip_special_chars"],
           "filter": [
-            "rdm_lowercase",
-            "rdm_asciifolding"
+            "lowercasepreserveoriginal",
+            "asciifoldingpreserveoriginal"
           ]
         }
       },
@@ -40,11 +40,11 @@
         }
       },
       "filter": {
-        "rdm_lowercase": {
+        "lowercasepreserveoriginal": {
           "type": "lowercase",
           "preserve_original": true
         },
-        "rdm_asciifolding": {
+        "asciifoldingpreserveoriginal": {
           "type": "asciifolding",
           "preserve_original": true
         },

--- a/invenio_vocabularies/contrib/funders/mappings/os-v2/funders/funder-v2.0.0.json
+++ b/invenio_vocabularies/contrib/funders/mappings/os-v2/funders/funder-v2.0.0.json
@@ -14,8 +14,8 @@
           "type": "custom",
           "char_filter": ["strip_special_chars"],
           "filter": [
-            "lowercase",
-            "asciifolding",
+            "rdm_lowercase",
+            "rdm_asciifolding",
             "edgegrams"
           ]
         },
@@ -24,8 +24,8 @@
           "type": "custom",
           "char_filter": ["strip_special_chars"],
           "filter": [
-            "lowercase",
-            "asciifolding"
+            "rdm_lowercase",
+            "rdm_asciifolding"
           ]
         }
       },
@@ -40,11 +40,11 @@
         }
       },
       "filter": {
-        "lowercase": {
+        "rdm_lowercase": {
           "type": "lowercase",
           "preserve_original": true
         },
-        "asciifolding": {
+        "rdm_asciifolding": {
           "type": "asciifolding",
           "preserve_original": true
         },

--- a/invenio_vocabularies/contrib/funders/mappings/os-v2/funders/funder-v2.0.0.json
+++ b/invenio_vocabularies/contrib/funders/mappings/os-v2/funders/funder-v2.0.0.json
@@ -14,8 +14,8 @@
           "type": "custom",
           "char_filter": ["strip_special_chars"],
           "filter": [
-            "rdm_lowercase",
-            "rdm_asciifolding",
+            "lowercasepreserveoriginal",
+            "asciifoldingpreserveoriginal",
             "edgegrams"
           ]
         },
@@ -24,8 +24,8 @@
           "type": "custom",
           "char_filter": ["strip_special_chars"],
           "filter": [
-            "rdm_lowercase",
-            "rdm_asciifolding"
+            "lowercasepreserveoriginal",
+            "asciifoldingpreserveoriginal"
           ]
         }
       },
@@ -40,11 +40,11 @@
         }
       },
       "filter": {
-        "rdm_lowercase": {
+        "lowercasepreserveoriginal": {
           "type": "lowercase",
           "preserve_original": true
         },
-        "rdm_asciifolding": {
+        "asciifoldingpreserveoriginal": {
           "type": "asciifolding",
           "preserve_original": true
         },


### PR DESCRIPTION
:heart: Thank you for your contribution!

Close #408 

### Description

The normalizer that was introduced in the funders index with v5.1.0 generates two tokens when used on documents that contain diacritics in the acronym. This behaviour occurs when in the filter definition `"preserve_original": true` is used. This is ok for analyzers, so this PR just renames the filters and takes care the analyzers use the new ones and the normailzer uses the original ones.


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
