### PR TITLE
awards: get program from CORDIS

### DIFF
--- a/tests/contrib/awards/test_awards_datastreams.py
+++ b/tests/contrib/awards/test_awards_datastreams.py
@@ -115,7 +115,7 @@ def expected_from_award_json_ec():
 
 
 CORDIS_PROJECT_XML = bytes(
-    """      
+    """
 <project
 	xmlns="http://cordis.europa.eu">
 	<language>en</language>
@@ -148,6 +148,16 @@ CORDIS_PROJECT_XML = bytes(
 					</categories>
 				</relations>
 			</organization>
+			<programme source="corda" uniqueProgrammePart="true" type="relatedLegalBasis">
+				<code>HORIZON.1.1</code>
+			</programme>
+			<programme source="corda" type="relatedLegalBasis">
+				<code>ANOTHER.CODE.WHICH.IS.NOT.THE.UNIQUE.PROGRAMME.PART</code>
+			</programme>
+			<programme source="corda" type="relatedTopic">
+				<code>ERC-2023-STG</code>
+				<frameworkProgramme>HORIZON</frameworkProgramme>
+			</programme>
 		</associations>
 		<categories>
 			<category classification="euroSciVoc" type="isInFieldOfScience">
@@ -169,6 +179,7 @@ CORDIS_PROJECT_XML = bytes(
 def expected_from_cordis_project_xml():
     return {
         "id": "00k4n6c32::101117736",
+        "program": "HORIZON.1.1",
         "subjects": [{"id": "euroscivoc:225"}],
         "organizations": [
             {


### PR DESCRIPTION
:heart: Thank you for your contribution!

Fixes #417

### Description

This pull request contains the logic for extracting the program from CORDIS.

The logic can be tested with the following commands:

```bash
invenio vocabularies convert -v awards:cordis -o "HE" -t he.yaml
invenio vocabularies convert -v awards:cordis -o "H2020" -t h2020.yaml
invenio vocabularies convert -v awards:cordis -o "FP7" -t fp7.yaml
```

Here are how many projects for each program is found for each of the 3 input files:

```
13674 entries in the HE file
   57 program: EURATOM
 3582 program: ERC
 4585 program: MSCA
 5450 program: Other HORIZON programmes

35386 entries in the H2020 file
   99 program: EURATOM
 7850 program: ERC
11807 program: MSCA
15630 program: Other H2020 programmes

19814 entries in the FP7 file
  125 program: EURATOM
 3151 program: ERC
 8256 program: MSCA
 8282 program: Other FP7 programmes
```

Which gives the following overall aggregated numbers:

```
68874 entries in total
  281 program: EURATOM
14583 program: ERC
24648 program: MSCA
 5450 program: Other HORIZON programmes
15630 program: Other H2020 programmes
 8282 program: Other FP7 programmes
```


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
