### PR TITLE
jobs: pass since as string to task

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@
 Changes
 =======
 
+Version v6.3.1 (released 2024-10-11)
+
+- jobs: pass since as string to task
+
 Version v6.3.0 (released 2024-10-11)
 
 - awards: get program from CORDIS

--- a/invenio_vocabularies/__init__.py
+++ b/invenio_vocabularies/__init__.py
@@ -10,6 +10,6 @@
 
 from .ext import InvenioVocabularies
 
-__version__ = "6.3.0"
+__version__ = "6.3.1"
 
 __all__ = ("__version__", "InvenioVocabularies")

--- a/invenio_vocabularies/jobs.py
+++ b/invenio_vocabularies/jobs.py
@@ -68,7 +68,7 @@ class ProcessRORAffiliationsJob(ProcessDataStreamJob):
             "config": {
                 "readers": [
                     {
-                        "args": {"since": since},
+                        "args": {"since": str(since)},
                         "type": "ror-http",
                     },
                     {"args": {"regex": "_schema_v2\\.json$"}, "type": "zip"},
@@ -111,7 +111,7 @@ class ProcessRORFundersJob(ProcessDataStreamJob):
             "config": {
                 "readers": [
                     {
-                        "args": {"since": since},
+                        "args": {"since": str(since)},
                         "type": "ror-http",
                     },
                     {"args": {"regex": "_schema_v2\\.json$"}, "type": "zip"},


### PR DESCRIPTION
This fixes the error `TypeError: can not serialize 'datetime.datetime' object` which happens when scheduling a job with the stack trace:

```
Traceback (most recent call last):
File "/usr/local/lib/python3.9/site-packages/kombu/serialization.py", line 41, in _reraise_errors
yield
File "/usr/local/lib/python3.9/site-packages/kombu/serialization.py", line 220, in dumps
payload = encoder(data)
File "/usr/local/lib/python3.9/site-packages/kombu/serialization.py", line 368, in pack
return packb(s, use_bin_type=True)
File "/usr/local/lib64/python3.9/site-packages/msgpack/__init__.py", line 36, in packb
```