### PR TITLE
awards: rollback to use the 2nd part of funding stream as program

### DIFF
--- a/invenio_vocabularies/contrib/awards/datastreams.py
+++ b/invenio_vocabularies/contrib/awards/datastreams.py
@@ -74,7 +74,10 @@ class OpenAIREProjectTransformer(BaseTransformer):
 
         funding = next(iter(record.get("funding", [])), None)
         if funding:
-            program = funding.get("fundingStream", {}).get("id", "")
+            funding_stream_id = funding.get("fundingStream", {}).get("id", "")
+            # Example funding stream ID: `EC::HE::HORIZON-AG-UN`. We need the `HE`
+            # string, i.e. the second "part" of the identifier.
+            program = next(iter(funding_stream_id.split("::")[1:2]), "")
             if program:
                 award["program"] = program
 

--- a/tests/contrib/awards/test_awards_datastreams.py
+++ b/tests/contrib/awards/test_awards_datastreams.py
@@ -92,7 +92,7 @@ def expected_from_award_json():
         "id": "021nxhr62::0751743",
         "identifiers": [{"identifier": "https://test.com", "scheme": "url"}],
         "number": "0751743",
-        "program": "NSF::GEO/OAD::GEO/OCE",
+        "program": "GEO/OAD",
         "title": {"en": "Test title"},
         "funder": {"id": "021nxhr62"},
         "acronym": "TA",
@@ -110,7 +110,7 @@ def expected_from_award_json_ec():
         "title": {"en": "Test title"},
         "funder": {"id": "00k4n6c32"},
         "acronym": "TS",
-        "program": "TST::test::test",
+        "program": "test",
     }
 
 


### PR DESCRIPTION
:heart: Thank you for your contribution!

Partially fixes #417

### Description

* In #402 we changed from storing only a program like `HE` to storing the full string `EC::HE::HORIZON-TMA-MSCA-DN-ID`, because we thought was we would be able to easily identify sub-programmes like MSCA, ERC and EURATOM like this.
* In the end, we are now getting the more detailed sub-programmes from CORDIS (see #412).
* We are proposing to rollback this change so that if the project does not exist yet in CORDIS (this is for instance the case of https://cordis.europa.eu/project/id/101196872), then we can still fall back on `HE` and at least know that this is not `H2020` and `FP7` (although we won't be able to know if it's MSCA, ERC or EURATOM).

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
3. You agree that you have the right to license your contribution under the current repository’s license.
