### PR TITLE
awards/schema.py: read app config for alternate funding validation

### DIFF
--- a/invenio_vocabularies/assets/semantic-ui/js/invenio_vocabularies/src/contrib/forms/Funding/FundingModal.js
+++ b/invenio_vocabularies/assets/semantic-ui/js/invenio_vocabularies/src/contrib/forms/Funding/FundingModal.js
@@ -52,37 +52,13 @@ const CustomFundingSchema = Yup.object().shape({
       id: Yup.string().required(i18next.t("Funder is required.")),
     }),
     award: Yup.object().shape({
-      title: Yup.string().test({
-        name: "testTitle",
-        message: i18next.t("Title must be set alongside number."),
-        test: function testTitle(value) {
-          const { number } = this.parent;
-
-          if (number && !value) {
-            return false;
-          }
-
-          return true;
-        },
-      }),
-      number: Yup.string().test({
-        name: "testNumber",
-        message: i18next.t("Number must be set alongside title."),
-        test: function testNumber(value) {
-          const { title } = this.parent;
-
-          if (title && !value) {
-            return false;
-          }
-
-          return true;
-        },
-      }),
+      title: Yup.string(),
+      number: Yup.string(),
       url: Yup.string()
         .url(i18next.t("URL must be valid."))
         .test({
           name: "validateUrlDependencies",
-          message: i18next.t("URL must be set alongside title and number."),
+          message: i18next.t("URL must be set alongside title or number."),
           test: function testUrl(value) {
             const { title, number } = this.parent;
 

--- a/invenio_vocabularies/contrib/awards/schema.py
+++ b/invenio_vocabularies/contrib/awards/schema.py
@@ -8,6 +8,7 @@
 
 """Awards schema."""
 
+from flask import current_app
 from functools import partial
 
 from invenio_i18n import lazy_gettext as _
@@ -90,10 +91,21 @@ class AwardRelationSchema(Schema):
         id_ = data.get("id")
         number = data.get("number")
         title = data.get("title")
-        if not id_ and not (number and title):
-            raise ValidationError(
-                _("An existing id or number/title must be present."), "award"
-            )
+        try:
+            ALTERNATE_FUNDING_SCHEMA = current_app.config["ALTERNATE_FUNDING_SCHEMA"]
+        except KeyError:
+            ALTERNATE_FUNDING_SCHEMA = None
+        if ALTERNATE_FUNDING_SCHEMA:
+            if not id_ and not (number or title):
+                raise ValidationError(
+                    _("An existing id or either number or title must be present."),
+                    "award",
+                )
+        else:
+            if not id_ and not (number and title):
+                raise ValidationError(
+                    _("An existing id or number/title must be present."), "award"
+                )
 
 
 class FundingRelationSchema(Schema):

--- a/invenio_vocabularies/contrib/awards/schema.py
+++ b/invenio_vocabularies/contrib/awards/schema.py
@@ -8,7 +8,6 @@
 
 """Awards schema."""
 
-from flask import current_app
 from functools import partial
 
 from invenio_i18n import lazy_gettext as _

--- a/invenio_vocabularies/contrib/awards/schema.py
+++ b/invenio_vocabularies/contrib/awards/schema.py
@@ -91,21 +91,12 @@ class AwardRelationSchema(Schema):
         id_ = data.get("id")
         number = data.get("number")
         title = data.get("title")
-        try:
-            ALTERNATE_FUNDING_SCHEMA = current_app.config["ALTERNATE_FUNDING_SCHEMA"]
-        except KeyError:
-            ALTERNATE_FUNDING_SCHEMA = None
-        if ALTERNATE_FUNDING_SCHEMA:
-            if not id_ and not (number or title):
-                raise ValidationError(
-                    _("An existing id or either number or title must be present."),
-                    "award",
-                )
-        else:
-            if not id_ and not (number and title):
-                raise ValidationError(
-                    _("An existing id or number/title must be present."), "award"
-                )
+
+        if not id_ and not (number or title):
+            raise ValidationError(
+                _("An existing id or either number or title must be present."),
+                "award",
+            )
 
 
 class FundingRelationSchema(Schema):


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Hi, in order to enable institutions to use a less strict validation for funding entries that still adheres to Datacite this PR adds a global conf variable that when set allows an alternative validation of a funding entry. 

Right now Invenio wants if either an award number or title is entered the other:

![image](https://github.com/user-attachments/assets/2e2fe4c9-405c-4912-90a0-5509e6f1400a)

This is not required by DataCite: https://datacite-metadata-schema.readthedocs.io/en/4.5/properties/fundingreference/

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).



**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
