### PR TITLE
datastreams: affiliations: add EDMO organizations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
   Python:
     uses: inveniosoftware/workflows/.github/workflows/tests-python.yml@master
     with:
-      extras: "tests,oaipmh"
+      extras: "tests,oaipmh,rdf,sparql"
 
   JS:
     uses: inveniosoftware/workflows/.github/workflows/tests-js.yml@master

--- a/invenio_vocabularies/config.py
+++ b/invenio_vocabularies/config.py
@@ -196,10 +196,6 @@ VOCABULARIES_SUBJECTS_GEMET_FILE_URL = (
 )
 """Subject GEMET file download link."""
 
-VOCABULARIES_AFFILIATIONS_EDMO_SPARQL_URL = "https://edmo.seadatanet.org/sparql/sparql"
-"""Affiliations EDMO SPARQL URL."""
-
-
 VOCABULARIES_AFFILIATIONS_EDMO_COUNTRY_MAPPING = {
     "Cape Verde": "Cabo Verde",
 }

--- a/invenio_vocabularies/config.py
+++ b/invenio_vocabularies/config.py
@@ -10,6 +10,8 @@
 
 """Vocabularies configuration."""
 
+import re
+
 import idutils
 from invenio_i18n import lazy_gettext as _
 
@@ -21,6 +23,7 @@ from .datastreams.readers import (
     OAIPMHReader,
     RDFReader,
     SimpleHTTPReader,
+    SPARQLReader,
     TarReader,
     XMLReader,
     YamlReader,
@@ -45,6 +48,8 @@ VOCABULARIES_IDENTIFIER_SCHEMES = {
 }
 """"Generic identifier schemes, usable by other vocabularies."""
 
+edmo_regexp = re.compile(r"^https://edmo\.seadatanet\.org/report/\d+$")
+
 
 def is_pic(val):
     """Test if argument is a Participant Identification Code (PIC)."""
@@ -53,9 +58,15 @@ def is_pic(val):
     return val.isdigit()
 
 
+def is_edmo(val):
+    """Test if argument is a European Directory of Marine Organisations (EDMO) identifier."""
+    return edmo_regexp.match(val)
+
+
 VOCABULARIES_AFFILIATION_SCHEMES = {
     **VOCABULARIES_IDENTIFIER_SCHEMES,
     "pic": {"label": _("PIC"), "validator": is_pic},
+    "edmo": {"label": _("EDMO"), "validator": is_edmo},
 }
 """Affiliations allowed identifier schemes."""
 
@@ -139,6 +150,7 @@ VOCABULARIES_DATASTREAM_READERS = {
     "tar": TarReader,
     "http": SimpleHTTPReader,
     "rdf": RDFReader,
+    "sparql": SPARQLReader,
     "yaml": YamlReader,
     "zip": ZipReader,
     "xml": XMLReader,
@@ -183,6 +195,15 @@ VOCABULARIES_SUBJECTS_GEMET_FILE_URL = (
     "https://www.eionet.europa.eu/gemet/latest/gemet.rdf.gz"
 )
 """Subject GEMET file download link."""
+
+VOCABULARIES_AFFILIATIONS_EDMO_SPARQL_URL = "https://edmo.seadatanet.org/sparql/sparql"
+"""Affiliations EDMO SPARQL URL."""
+
+
+VOCABULARIES_AFFILIATIONS_EDMO_COUNTRY_MAPPING = {
+    "Cape Verde": "Cabo Verde",
+}
+"""Affiliations EDMO Country name remapping dictionary."""
 
 VOCABULARIES_ORCID_ACCESS_KEY = "TODO"
 """ORCID access key to access the s3 bucket."""

--- a/invenio_vocabularies/contrib/affiliations/config.py
+++ b/invenio_vocabularies/contrib/affiliations/config.py
@@ -21,15 +21,10 @@ from ...services.components import PIDComponent
 affiliation_schemes = LocalProxy(
     lambda: current_app.config["VOCABULARIES_AFFILIATION_SCHEMES"]
 )
-localized_title = LocalProxy(lambda: f"title.{get_locale()}^20")
-
-affiliation_edmo_sparql_url = LocalProxy(
-    lambda: current_app.config["VOCABULARIES_AFFILIATIONS_EDMO_SPARQL_URL"]
-)
-
 affiliation_edmo_country_mappings = LocalProxy(
     lambda: current_app.config["VOCABULARIES_AFFILIATIONS_EDMO_COUNTRY_MAPPING"]
 )
+localized_title = LocalProxy(lambda: f"title.{get_locale()}^20")
 
 
 class AffiliationsSearchOptions(SearchOptions):

--- a/invenio_vocabularies/contrib/affiliations/config.py
+++ b/invenio_vocabularies/contrib/affiliations/config.py
@@ -23,6 +23,14 @@ affiliation_schemes = LocalProxy(
 )
 localized_title = LocalProxy(lambda: f"title.{get_locale()}^20")
 
+affiliation_edmo_sparql_url = LocalProxy(
+    lambda: current_app.config["VOCABULARIES_AFFILIATIONS_EDMO_SPARQL_URL"]
+)
+
+affiliation_edmo_country_mappings = LocalProxy(
+    lambda: current_app.config["VOCABULARIES_AFFILIATIONS_EDMO_COUNTRY_MAPPING"]
+)
+
 
 class AffiliationsSearchOptions(SearchOptions):
     """Search options."""

--- a/invenio_vocabularies/contrib/affiliations/datastreams.py
+++ b/invenio_vocabularies/contrib/affiliations/datastreams.py
@@ -13,17 +13,12 @@ from copy import deepcopy
 
 import pycountry
 from flask import current_app
-from SPARQLWrapper import JSON, SPARQLWrapper
 
 from ...datastreams import StreamEntry
-from ...datastreams.errors import TransformerError, WriterError
-from ...datastreams.readers import BaseReader
+from ...datastreams.errors import TransformerError
 from ...datastreams.transformers import BaseTransformer
 from ...datastreams.writers import ServiceWriter
-from ..affiliations.config import (
-    affiliation_edmo_country_mappings,
-    affiliation_edmo_sparql_url,
-)
+from ..affiliations.config import affiliation_edmo_country_mappings
 from ..common.ror.datastreams import RORTransformer
 
 

--- a/invenio_vocabularies/contrib/subjects/euroscivoc/datastreams.py
+++ b/invenio_vocabularies/contrib/subjects/euroscivoc/datastreams.py
@@ -19,7 +19,7 @@ class EuroSciVocSubjectsTransformer(RDFTransformer):
     def _get_notation(self, subject, rdf_graph):
         """Extract the numeric notation for a subject."""
         for _, _, notation in rdf_graph.triples(
-            (subject, self.SKOS_CORE.notation, None)
+            (subject, self.skos_core.notation, None)
         ):
             if str(notation).isdigit():
                 return str(notation)
@@ -33,7 +33,7 @@ class EuroSciVocSubjectsTransformer(RDFTransformer):
         notation = self._get_notation(subject, rdf_graph)
         id = f"euroscivoc:{notation}" if notation else None
         labels = self._get_labels(subject, rdf_graph)
-        parents = self.SPLITCHAR.join(
+        parents = ",".join(
             f"euroscivoc:{n}"
             for n in reversed(self._find_parents(subject, rdf_graph))
             if n

--- a/invenio_vocabularies/factories.py
+++ b/invenio_vocabularies/factories.py
@@ -17,6 +17,9 @@ from .contrib.affiliations.datastreams import (
     DATASTREAM_CONFIG as affiliations_ds_config,
 )
 from .contrib.affiliations.datastreams import (
+    DATASTREAM_CONFIG_EDMO as affiliations_edmo_ds_config,
+)
+from .contrib.affiliations.datastreams import (
     DATASTREAM_CONFIG_OPENAIRE as affiliations_openaire_ds_config,
 )
 from .contrib.awards.datastreams import DATASTREAM_CONFIG as awards_ds_config
@@ -123,6 +126,17 @@ class AffiliationsOpenAIREVocabularyConfig(VocabularyConfig):
         raise NotImplementedError("Service not implemented for OpenAIRE Affiliations")
 
 
+class AffiliationsEDMOVocabularyConfig(VocabularyConfig):
+    """European Directory of Marine Organisations (EDMO) Affiliations Vocabulary Config."""
+
+    config = affiliations_edmo_ds_config
+    vocabulary_name = "affiliations:edmo"
+
+    def get_service(self):
+        """Get the service for the vocabulary."""
+        raise NotImplementedError("Service not implemented for EDMO Affiliations")
+
+
 def get_vocabulary_config(vocabulary):
     """Factory function to get the appropriate Vocabulary Config."""
     vocab_config = {
@@ -132,6 +146,7 @@ def get_vocabulary_config(vocabulary):
         "awards:cordis": AwardsCordisVocabularyConfig,
         "affiliations": AffiliationsVocabularyConfig,
         "affiliations:openaire": AffiliationsOpenAIREVocabularyConfig,
+        "affiliations:edmo": AffiliationsEDMOVocabularyConfig,
         "subjects": SubjectsVocabularyConfig,
     }
     return vocab_config.get(vocabulary, VocabularyConfig)()

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,6 @@ install_requires =
     pycountry>=22.3.5,<23.0.0
     PyYAML>=5.4.1
     regex>=2024.7.24
-    rdflib>=7.0.0
     SPARQLWrapper>=2.0.0
 
 [options.extras_require]
@@ -44,6 +43,10 @@ s3fs =
     s3fs>=2024.6.1
 oaipmh =
     invenio-oaipmh-scythe>=0.13.0
+rdf =
+    rdflib>=7.0.0
+sparql =
+    SPARQLWrapper>=2.0.0
 tests =
     pytest-black-ng>=0.4.0
     invenio-app>=1.4.0,<2.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,9 +32,12 @@ install_requires =
     invenio-administration>=2.0.0,<3.0.0
     invenio-jobs>=1.0.0,<2.0.0
     lxml>=4.5.0
+    # Upper pinning pycountry due to commonmeta-py
+    pycountry>=22.3.5,<23.0.0
     PyYAML>=5.4.1
     regex>=2024.7.24
     rdflib>=7.0.0
+    SPARQLWrapper>=2.0.0
 
 [options.extras_require]
 s3fs =

--- a/tests/contrib/subjects/euroscivoc/test_subjects_euroscivoc_datastream.py
+++ b/tests/contrib/subjects/euroscivoc/test_subjects_euroscivoc_datastream.py
@@ -9,7 +9,7 @@
 import io
 
 import pytest
-from rdflib import RDF, Graph
+from rdflib import Graph
 
 from invenio_vocabularies.contrib.subjects.euroscivoc.datastreams import (
     EuroSciVocSubjectsTransformer,

--- a/tests/contrib/subjects/gemet/test_subjects_gemet_datastream.py
+++ b/tests/contrib/subjects/gemet/test_subjects_gemet_datastream.py
@@ -9,7 +9,7 @@
 import io
 
 import pytest
-from rdflib import RDF, Graph
+from rdflib import Graph
 
 from invenio_vocabularies.contrib.subjects.gemet.datastreams import (
     GEMETSubjectsTransformer,


### PR DESCRIPTION
:heart: Thank you for your contribution!

Fixes #433 

### Description

The pull requests provides a new datastream to import affiliations from the [European Directory of Marine Organisations (EDMO)](https://edmo.seadatanet.org/).
There is no official mapping between EDMO and ROR, so for now we are importing them separately with a different main ID scheme.

There is no downloadable RDF file containing all the data, so we need to call a SPARQL endpoint in order to import the data.

The data can be imported with the following command:
```bash
$ invenio vocabularies import --vocabulary affiliations:edmo --origin https://edmo.seadatanet.org/sparql/sparql
EDMOOrganizationTransformer: ["No alpha_2 country found for: {'org': {'type': 'uri', 'value': 'https://edmo.seadatanet.org/report/1051'}, 'name': {'type': 'literal', 'value': 'UNKNOWN'}, 'countryName': {'type': 'literal', 'value': 'Unknown'}, 'locality': {'type': 'literal', 'value': 'UNKNOWN'}, 'deprecated': {'type': 'literal', 'datatype': 'http://www.w3.org/2001/XMLSchema#boolean', 'value': 'false'}}"]
Vocabulary affiliations:edmo imported. Total items 5656. 
5655 items succeeded
1 contained errors
0 were filtered.
```

Affiliations organizations autocomplete showing ROR and EDMO organizations side by side:
![Affiliations organizations autocomplete](https://github.com/user-attachments/assets/a160c90e-f472-4281-86ac-20d9f967b2d1)

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
