### PR TITLE
Gemet vocab

### DIFF
--- a/invenio_vocabularies/config.py
+++ b/invenio_vocabularies/config.py
@@ -19,6 +19,8 @@ from .datastreams.readers import (
     JsonLinesReader,
     JsonReader,
     OAIPMHReader,
+    RDFReader,
+    SimpleHTTPReader,
     TarReader,
     XMLReader,
     YamlReader,
@@ -135,6 +137,8 @@ VOCABULARIES_DATASTREAM_READERS = {
     "jsonl": JsonLinesReader,
     "gzip": GzipReader,
     "tar": TarReader,
+    "http": SimpleHTTPReader,
+    "rdf": RDFReader,
     "yaml": YamlReader,
     "zip": ZipReader,
     "xml": XMLReader,
@@ -172,8 +176,13 @@ VOCABULARIES_TYPES_SEARCH = {
 }
 """Vocabulary type search configuration."""
 
-SUBJECTS_EUROSCIVOC_FILE_URL = "https://publications.europa.eu/resource/distribution/euroscivoc/rdf/skos_ap_eu/EuroSciVoc-skos-ap-eu.rdf"
+VOCABULARIES_SUBJECTS_EUROSCIVOC_FILE_URL = "https://publications.europa.eu/resource/distribution/euroscivoc/rdf/skos_ap_eu/EuroSciVoc-skos-ap-eu.rdf"
 """Subject EuroSciVoc file download link."""
+
+VOCABULARIES_SUBJECTS_GEMET_FILE_URL = (
+    "https://www.eionet.europa.eu/gemet/latest/gemet.rdf.gz"
+)
+"""Subject GEMET file download link."""
 
 VOCABULARIES_ORCID_ACCESS_KEY = "TODO"
 """ORCID access key to access the s3 bucket."""

--- a/invenio_vocabularies/contrib/subjects/config.py
+++ b/invenio_vocabularies/contrib/subjects/config.py
@@ -26,6 +26,15 @@ subject_schemes = LocalProxy(
 localized_title = LocalProxy(lambda: f"title.{get_locale()}^20")
 
 
+gemet_file_url = LocalProxy(
+    lambda: current_app.config["VOCABULARIES_SUBJECTS_GEMET_FILE_URL"]
+)
+
+euroscivoc_file_url = LocalProxy(
+    lambda: current_app.config["VOCABULARIES_SUBJECTS_EUROSCIVOC_FILE_URL"]
+)
+
+
 class SubjectsSearchOptions(SearchOptions):
     """Search options."""
 

--- a/invenio_vocabularies/contrib/subjects/datastreams.py
+++ b/invenio_vocabularies/contrib/subjects/datastreams.py
@@ -13,6 +13,7 @@ from invenio_i18n import lazy_gettext as _
 
 from ...datastreams.writers import ServiceWriter
 from .euroscivoc import datastreams as euroscivoc_datastreams
+from .gemet import datastreams as gemet_datastreams
 from .mesh import datastreams as mesh_datastreams
 
 
@@ -32,12 +33,14 @@ class SubjectsServiceWriter(ServiceWriter):
 VOCABULARIES_DATASTREAM_READERS = {
     **mesh_datastreams.VOCABULARIES_DATASTREAM_READERS,
     **euroscivoc_datastreams.VOCABULARIES_DATASTREAM_READERS,
+    **gemet_datastreams.VOCABULARIES_DATASTREAM_READERS,
 }
 """Subjects Data Streams readers."""
 
 VOCABULARIES_DATASTREAM_TRANSFORMERS = {
     **mesh_datastreams.VOCABULARIES_DATASTREAM_TRANSFORMERS,
     **euroscivoc_datastreams.VOCABULARIES_DATASTREAM_TRANSFORMERS,
+    **gemet_datastreams.VOCABULARIES_DATASTREAM_TRANSFORMERS,
 }
 """Subjects Data Streams transformers."""
 
@@ -45,6 +48,7 @@ VOCABULARIES_DATASTREAM_WRITERS = {
     "subjects-service": SubjectsServiceWriter,
     **mesh_datastreams.VOCABULARIES_DATASTREAM_WRITERS,
     **euroscivoc_datastreams.VOCABULARIES_DATASTREAM_WRITERS,
+    **gemet_datastreams.VOCABULARIES_DATASTREAM_WRITERS,
 }
 """Subjects Data Streams writers."""
 

--- a/invenio_vocabularies/contrib/subjects/euroscivoc/datastreams.py
+++ b/invenio_vocabularies/contrib/subjects/euroscivoc/datastreams.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2022-2024 CERN.
+# Copyright (C) 2024 CERN.
 #
 # Invenio-Vocabularies is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -8,70 +8,13 @@
 
 """EuroSciVoc subjects datastreams, readers, transformers, and writers."""
 
-import io
-from collections import namedtuple
+from invenio_vocabularies.datastreams.transformers import RDFTransformer
 
-import requests
-from rdflib import OWL, RDF, Graph, Namespace
-
-from invenio_vocabularies.config import SUBJECTS_EUROSCIVOC_FILE_URL
-from invenio_vocabularies.datastreams.readers import BaseReader
-from invenio_vocabularies.datastreams.transformers import BaseTransformer
+from ..config import euroscivoc_file_url
 
 
-class EuroSciVocSubjectsHTTPReader(BaseReader):
-    """Reader class to fetch and process EuroSciVoc RDF data."""
-
-    def __init__(self, origin=None, mode="r", since=None, *args, **kwargs):
-        """Initialize the reader with the data source.
-
-        :param origin: The URL from which to fetch the RDF data.
-        :param mode: Mode of operation (default is 'r' for reading).
-        """
-        self.origin = origin or SUBJECTS_EUROSCIVOC_FILE_URL
-        super().__init__(origin=origin, mode=mode, *args, **kwargs)
-
-    def _iter(self, rdf_graph):
-        """Iterate over the RDF graph, yielding one subject at a time.
-
-        :param rdf_graph: The RDF graph to process.
-        :yield: Subject and graph to be transformed.
-        """
-        SKOS_CORE = Namespace("http://www.w3.org/2004/02/skos/core#")
-
-        for subject, _, _ in rdf_graph.triples((None, RDF.type, SKOS_CORE.Concept)):
-            yield {"subject": subject, "rdf_graph": rdf_graph}
-
-    def read(self, item=None, *args, **kwargs):
-        """Fetch and process the EuroSciVoc RDF data, yielding it one subject at a time.
-
-        :param item: The RDF data provided as bytes (optional).
-        :yield: Processed EuroSciVoc subject data.
-        """
-        if item:
-            raise NotImplementedError(
-                "EuroSciVocSubjectsHTTPReader does not support being chained after another reader"
-            )
-        # Fetch the RDF data from the specified origin URL
-        response = requests.get(self.origin)
-        response.raise_for_status()
-
-        # Treat the response content as a file-like object
-        rdf_data = io.BytesIO(response.content)
-
-        # Parse the RDF data into a graph
-        rdf_graph = Graph()
-        rdf_graph.parse(rdf_data, format="xml")
-
-        # Yield each processed subject from the RDF graph
-        yield from self._iter(rdf_graph)
-
-
-class EuroSciVocSubjectsTransformer(BaseTransformer):
+class EuroSciVocSubjectsTransformer(RDFTransformer):
     """Transformer class to convert EuroSciVoc RDF data to a dictionary format."""
-
-    SKOS_CORE = Namespace("http://www.w3.org/2004/02/skos/core#")
-    SPLITCHAR = ","
 
     def _get_notation(self, subject, rdf_graph):
         """Extract the numeric notation for a subject."""
@@ -82,46 +25,19 @@ class EuroSciVocSubjectsTransformer(BaseTransformer):
                 return str(notation)
         return None
 
-    def _get_labels(self, subject, rdf_graph):
-        """Extract prefLabel and altLabel languages for a subject."""
-        labels = {
-            label.language: label.value.capitalize()
-            for _, _, label in rdf_graph.triples(
-                (subject, self.SKOS_CORE.prefLabel, None)
-            )
-        }
-        if "en" not in labels:
-            for _, _, label in rdf_graph.triples(
-                (subject, self.SKOS_CORE.altLabel, None)
-            ):
-                labels.setdefault(label.language, label.value.capitalize())
-        return labels
-
-    def _find_parents(self, subject, rdf_graph):
-        """Find parent notations."""
-        parents = []
-
-        # Traverse the broader hierarchy
-        for broader in rdf_graph.transitive_objects(subject, self.SKOS_CORE.broader):
-            if broader != subject:  # Ensure we don't include the current subject
-                parent_notation = self._get_notation(broader, rdf_graph)
-                if parent_notation:
-                    parents.append(parent_notation)
-
-        return parents
+    def _get_parent_notation(self, broader, rdf_graph):
+        """Extract parent notation using numeric notation."""
+        return self._get_notation(broader, rdf_graph)
 
     def _transform_entry(self, subject, rdf_graph):
-        """Transform an entry to the required dictionary format."""
-        # Get subject notation with euroscivoc prefix
         notation = self._get_notation(subject, rdf_graph)
         id = f"euroscivoc:{notation}" if notation else None
-        # Get labels for the current subject
         labels = self._get_labels(subject, rdf_graph)
-        # Join parent notations with SPLITCHAR separator and add euroscivoc prefix
         parents = self.SPLITCHAR.join(
-            f"euroscivoc:{n}" for n in reversed(self._find_parents(subject, rdf_graph))
+            f"euroscivoc:{n}"
+            for n in reversed(self._find_parents(subject, rdf_graph))
+            if n
         )
-        # Create identifiers list
         identifiers = [{"scheme": "url", "identifier": str(subject)}]
 
         return {
@@ -133,23 +49,9 @@ class EuroSciVocSubjectsTransformer(BaseTransformer):
             "identifiers": identifiers,
         }
 
-    def apply(self, stream_entry, *args, **kwargs):
-        """Transform a stream entry to the required dictionary format.
 
-        :param stream_entry: The entry to be transformed, which includes the subject and the RDF graph.
-        :return: The transformed stream entry.
-        """
-        # Apply transformations
-        entry_data = self._transform_entry(
-            stream_entry.entry["subject"], stream_entry.entry["rdf_graph"]
-        )
-        stream_entry.entry = entry_data
-        return stream_entry
-
-
-# Configuration for datastream readers, transformers, and writers
-VOCABULARIES_DATASTREAM_READERS = {"euroscivoc-reader": EuroSciVocSubjectsHTTPReader}
-
+# Configuration for datastream transformers, and writers
+VOCABULARIES_DATASTREAM_READERS = {}
 VOCABULARIES_DATASTREAM_WRITERS = {}
 
 VOCABULARIES_DATASTREAM_TRANSFORMERS = {
@@ -159,8 +61,14 @@ VOCABULARIES_DATASTREAM_TRANSFORMERS = {
 DATASTREAM_CONFIG = {
     "readers": [
         {
-            "type": "euroscivoc-reader",
-        }
+            "type": "http",
+            "args": {
+                "origin": euroscivoc_file_url,
+            },
+        },
+        {
+            "type": "rdf",
+        },
     ],
     "transformers": [{"type": "euroscivoc-transformer"}],
     "writers": [

--- a/invenio_vocabularies/contrib/subjects/gemet/__init__.py
+++ b/invenio_vocabularies/contrib/subjects/gemet/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""GEMET Subjects module."""

--- a/invenio_vocabularies/contrib/subjects/gemet/datastreams.py
+++ b/invenio_vocabularies/contrib/subjects/gemet/datastreams.py
@@ -1,140 +1,66 @@
-import io
-from collections import namedtuple
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
 
-import requests
-from rdflib import OWL, RDF, Graph, Namespace, URIRef, Literal
+"""GEMET subjects datastreams, readers, transformers, and writers."""
+
 from rdflib.namespace import RDFS
-import gzip
-from invenio_vocabularies.config import SUBJECTS_EUROSCIVOC_FILE_URL
-from invenio_vocabularies.datastreams.readers import BaseReader
-from invenio_vocabularies.datastreams.transformers import BaseTransformer
+
+from invenio_vocabularies.datastreams.readers import RDFReader
+from invenio_vocabularies.datastreams.transformers import RDFTransformer
+
+from ..config import gemet_file_url
 
 
-class GEMETSubjectsHTTPReader(BaseReader):
-    """Reader class to fetch and process GEMET RDF data."""
-
-    def __init__(self, origin=None, mode="r", since=None, *args, **kwargs):
-        """Initialize the reader with the data source.
-
-        :param origin: The URL from which to fetch the RDF data.
-        :param mode: Mode of operation (default is 'r' for reading).
-        """
-        self.origin = 'https://www.eionet.europa.eu/gemet/latest/gemet.rdf.gz'
-        super().__init__(origin=origin, mode=mode, *args, **kwargs)
-
-    def _iter(self, rdf_graph):
-        """Iterate over the RDF graph, yielding one subject at a time.
-
-        :param rdf_graph: The RDF graph to process.
-        :yield: Subject and graph to be transformed.
-        """
-        SKOS_CORE = Namespace("http://www.w3.org/2004/02/skos/core#")
-
-        for subject, _, _ in rdf_graph.triples((None, RDF.type, SKOS_CORE.Concept)):
-            yield {"subject": subject, "rdf_graph": rdf_graph}
-
-    def read(self, item=None, *args, **kwargs):
-        """Fetch and process the GEMET RDF data, yielding it one subject at a time.
-
-        :param item: The RDF data provided as bytes (optional).
-        :yield: Processed GEMET subject data.
-        """
-        if item:
-            raise NotImplementedError(
-                "GEMETSubjectsHTTPReader does not support being chained after another reader"
-            )
-        # Fetch the RDF data from the specified origin URL
-        response = requests.get(self.origin)
-        response.raise_for_status()  # Check for HTTP errors
-
-        # Decompress the gzipped content
-        with gzip.GzipFile(fileobj=io.BytesIO(response.content)) as gzipped_file:
-            rdf_content = gzipped_file.read().decode('utf-8')
-
-        # Parse the decompressed RDF content
-        rdf_graph = Graph()
-        rdf_graph.parse(io.StringIO(rdf_content), format="xml")
-
-        # Yield each processed subject from the RDF graph
-        yield from self._iter(rdf_graph)
-
-
-class GEMETSubjectsTransformer(BaseTransformer):
+class GEMETSubjectsTransformer(RDFTransformer):
     """Transformer class to convert GEMET RDF data to a dictionary format."""
 
-    SKOS_CORE = Namespace("http://www.w3.org/2004/02/skos/core#")
-    SPLITCHAR = ","
-
-    def _get_labels(self, subject, rdf_graph):
-        """Extract prefLabel and altLabel languages for a subject, excluding languages with a hyphen in the code."""
-        labels = {
-            label.language: label.value.capitalize()
-            for _, _, label in rdf_graph.triples(
-                (subject, self.SKOS_CORE.prefLabel, None)
-            )
-            if '-' not in label.language  # Exclude languages with a hyphen in the code
-        }
-
-        if "en" not in labels:
-            for _, _, label in rdf_graph.triples(
-                (subject, self.SKOS_CORE.altLabel, None)
-            ):
-                # Only set labels if the language doesn't contain a hyphen
-                if '-' not in label.language:
-                    labels.setdefault(label.language, label.value.capitalize())
-                    
-        return labels
-
-
-    def _find_parents(self, subject, rdf_graph):
-        """Find parent notations."""
-        parents = []
-
-        # Traverse the broader hierarchy
-        for broader in rdf_graph.transitive_objects(subject, self.SKOS_CORE.broader):
-            if broader != subject:  # Ensure we don't include the current subject
-                parent_notation = '/'.join(broader.split('/')[-2:])
-                if parent_notation:
-                    parents.append(parent_notation)
-
-        return parents
+    def _get_parent_notation(self, broader, rdf_graph):
+        """Extract parent notation from GEMET URI."""
+        return "/".join(broader.split("/")[-2:])
 
     def _get_groups_and_themes(self, subject, rdf_graph):
         """Extract groups and themes for a subject."""
         groups = []
         themes = []
 
-        for relation in rdf_graph.subjects(predicate=self.SKOS_CORE.member, object=URIRef(subject)):
+        for relation in rdf_graph.subjects(
+            predicate=self.SKOS_CORE.member, object=subject
+        ):
             relation_uri = str(relation)
             relation_label = None
 
             # If the relation is a group, check for skos:prefLabel
             if "group" in relation_uri:
-                labels = rdf_graph.objects(subject=relation, predicate=self.SKOS_CORE.prefLabel)
-                relation_label = next((str(label) for label in labels if label.language == "en"), None)
+                labels = rdf_graph.objects(
+                    subject=relation, predicate=self.SKOS_CORE.prefLabel
+                )
+                relation_label = next(
+                    (str(label) for label in labels if label.language == "en"), None
+                )
+                groups.append(relation_uri)
 
             # If the relation is a theme, check for rdfs:label
             elif "theme" in relation_uri:
                 labels = rdf_graph.objects(subject=relation, predicate=RDFS.label)
-                relation_label = next((str(label) for label in labels if label.language == "en"), None)
-
-            # Add to themes or groups list
-            if "theme" in relation_uri:
+                relation_label = next(
+                    (str(label) for label in labels if label.language == "en"), None
+                )
                 themes.append(relation_uri)
-            else:
-                groups.append(relation_uri)
 
         return groups, themes
 
-
-
     def _transform_entry(self, subject, rdf_graph):
         """Transform an entry to the required dictionary format."""
-        concept_number = '/'.join(subject.split('/')[-2:])
+        concept_number = "/".join(subject.split("/")[-2:])
         id = f"gemet:{concept_number}" if concept_number else None
         labels = self._get_labels(subject, rdf_graph)
         parents = self.SPLITCHAR.join(
-            f"gemet:{n}" for n in reversed(self._find_parents(subject, rdf_graph))
+            f"gemet:{n}" for n in reversed(self._find_parents(subject, rdf_graph)) if n
         )
         identifiers = [{"scheme": "url", "identifier": str(subject)}]
         groups, themes = self._get_groups_and_themes(subject, rdf_graph)
@@ -145,14 +71,6 @@ class GEMETSubjectsTransformer(BaseTransformer):
             props["groups"] = groups
         if themes:
             props["themes"] = themes
-        x = {
-            "id": id,
-            "scheme": "GEMET",
-            "subject": labels.get("en", "").capitalize(),
-            "title": labels,
-            "props": props,
-            "identifiers": identifiers,
-        }
 
         return {
             "id": id,
@@ -163,39 +81,24 @@ class GEMETSubjectsTransformer(BaseTransformer):
             "identifiers": identifiers,
         }
 
-    def apply(self, stream_entry, *args, **kwargs):
-        """Transform a stream entry to the required dictionary format.
 
-        :param stream_entry: The entry to be transformed, which includes the subject and the RDF graph.
-        :return: The transformed stream entry.
-        """
-        # Apply transformations
-        entry_data = self._transform_entry(
-            stream_entry.entry["subject"], stream_entry.entry["rdf_graph"]
-        )
-        stream_entry.entry = entry_data
-        return stream_entry
-
-
-# Configuration for datastream readers, transformers, and writers
-VOCABULARIES_DATASTREAM_READERS = {"gemet-reader": GEMETSubjectsHTTPReader}
-
+# Configuration for datastream transformers, and writers
+VOCABULARIES_DATASTREAM_READERS = {}
 VOCABULARIES_DATASTREAM_WRITERS = {}
 
-VOCABULARIES_DATASTREAM_TRANSFORMERS = {
-    "gemet-transformer": GEMETSubjectsTransformer
-}
+VOCABULARIES_DATASTREAM_TRANSFORMERS = {"gemet-transformer": GEMETSubjectsTransformer}
 
 DATASTREAM_CONFIG = {
     "readers": [
         {
-            "type": "gemet-reader",
-        }
+            "type": "http",
+            "args": {
+                "origin": gemet_file_url,
+            },
+        },
+        {"type": "gzip"},
+        {"type": "rdf"},
     ],
     "transformers": [{"type": "gemet-transformer"}],
-    "writers": [
-        {
-            "type": "subjects-service",
-        }
-    ],
+    "writers": [{"args": {"writer": {"type": "subjects-service"}}, "type": "async"}],
 }

--- a/invenio_vocabularies/contrib/subjects/gemet/datastreams.py
+++ b/invenio_vocabularies/contrib/subjects/gemet/datastreams.py
@@ -1,0 +1,201 @@
+import io
+from collections import namedtuple
+
+import requests
+from rdflib import OWL, RDF, Graph, Namespace, URIRef, Literal
+from rdflib.namespace import RDFS
+import gzip
+from invenio_vocabularies.config import SUBJECTS_EUROSCIVOC_FILE_URL
+from invenio_vocabularies.datastreams.readers import BaseReader
+from invenio_vocabularies.datastreams.transformers import BaseTransformer
+
+
+class GEMETSubjectsHTTPReader(BaseReader):
+    """Reader class to fetch and process GEMET RDF data."""
+
+    def __init__(self, origin=None, mode="r", since=None, *args, **kwargs):
+        """Initialize the reader with the data source.
+
+        :param origin: The URL from which to fetch the RDF data.
+        :param mode: Mode of operation (default is 'r' for reading).
+        """
+        self.origin = 'https://www.eionet.europa.eu/gemet/latest/gemet.rdf.gz'
+        super().__init__(origin=origin, mode=mode, *args, **kwargs)
+
+    def _iter(self, rdf_graph):
+        """Iterate over the RDF graph, yielding one subject at a time.
+
+        :param rdf_graph: The RDF graph to process.
+        :yield: Subject and graph to be transformed.
+        """
+        SKOS_CORE = Namespace("http://www.w3.org/2004/02/skos/core#")
+
+        for subject, _, _ in rdf_graph.triples((None, RDF.type, SKOS_CORE.Concept)):
+            yield {"subject": subject, "rdf_graph": rdf_graph}
+
+    def read(self, item=None, *args, **kwargs):
+        """Fetch and process the GEMET RDF data, yielding it one subject at a time.
+
+        :param item: The RDF data provided as bytes (optional).
+        :yield: Processed GEMET subject data.
+        """
+        if item:
+            raise NotImplementedError(
+                "GEMETSubjectsHTTPReader does not support being chained after another reader"
+            )
+        # Fetch the RDF data from the specified origin URL
+        response = requests.get(self.origin)
+        response.raise_for_status()  # Check for HTTP errors
+
+        # Decompress the gzipped content
+        with gzip.GzipFile(fileobj=io.BytesIO(response.content)) as gzipped_file:
+            rdf_content = gzipped_file.read().decode('utf-8')
+
+        # Parse the decompressed RDF content
+        rdf_graph = Graph()
+        rdf_graph.parse(io.StringIO(rdf_content), format="xml")
+
+        # Yield each processed subject from the RDF graph
+        yield from self._iter(rdf_graph)
+
+
+class GEMETSubjectsTransformer(BaseTransformer):
+    """Transformer class to convert GEMET RDF data to a dictionary format."""
+
+    SKOS_CORE = Namespace("http://www.w3.org/2004/02/skos/core#")
+    SPLITCHAR = ","
+
+    def _get_labels(self, subject, rdf_graph):
+        """Extract prefLabel and altLabel languages for a subject, excluding languages with a hyphen in the code."""
+        labels = {
+            label.language: label.value.capitalize()
+            for _, _, label in rdf_graph.triples(
+                (subject, self.SKOS_CORE.prefLabel, None)
+            )
+            if '-' not in label.language  # Exclude languages with a hyphen in the code
+        }
+
+        if "en" not in labels:
+            for _, _, label in rdf_graph.triples(
+                (subject, self.SKOS_CORE.altLabel, None)
+            ):
+                # Only set labels if the language doesn't contain a hyphen
+                if '-' not in label.language:
+                    labels.setdefault(label.language, label.value.capitalize())
+                    
+        return labels
+
+
+    def _find_parents(self, subject, rdf_graph):
+        """Find parent notations."""
+        parents = []
+
+        # Traverse the broader hierarchy
+        for broader in rdf_graph.transitive_objects(subject, self.SKOS_CORE.broader):
+            if broader != subject:  # Ensure we don't include the current subject
+                parent_notation = '/'.join(broader.split('/')[-2:])
+                if parent_notation:
+                    parents.append(parent_notation)
+
+        return parents
+
+    def _get_groups_and_themes(self, subject, rdf_graph):
+        """Extract groups and themes for a subject."""
+        groups = []
+        themes = []
+
+        for relation in rdf_graph.subjects(predicate=self.SKOS_CORE.member, object=URIRef(subject)):
+            relation_uri = str(relation)
+            relation_label = None
+
+            # If the relation is a group, check for skos:prefLabel
+            if "group" in relation_uri:
+                labels = rdf_graph.objects(subject=relation, predicate=self.SKOS_CORE.prefLabel)
+                relation_label = next((str(label) for label in labels if label.language == "en"), None)
+
+            # If the relation is a theme, check for rdfs:label
+            elif "theme" in relation_uri:
+                labels = rdf_graph.objects(subject=relation, predicate=RDFS.label)
+                relation_label = next((str(label) for label in labels if label.language == "en"), None)
+
+            # Add to themes or groups list
+            if "theme" in relation_uri:
+                themes.append(relation_uri)
+            else:
+                groups.append(relation_uri)
+
+        return groups, themes
+
+
+
+    def _transform_entry(self, subject, rdf_graph):
+        """Transform an entry to the required dictionary format."""
+        concept_number = '/'.join(subject.split('/')[-2:])
+        id = f"gemet:{concept_number}" if concept_number else None
+        labels = self._get_labels(subject, rdf_graph)
+        parents = self.SPLITCHAR.join(
+            f"gemet:{n}" for n in reversed(self._find_parents(subject, rdf_graph))
+        )
+        identifiers = [{"scheme": "url", "identifier": str(subject)}]
+        groups, themes = self._get_groups_and_themes(subject, rdf_graph)
+
+        props = {"parents": parents} if parents else {}
+
+        if groups:
+            props["groups"] = groups
+        if themes:
+            props["themes"] = themes
+        x = {
+            "id": id,
+            "scheme": "GEMET",
+            "subject": labels.get("en", "").capitalize(),
+            "title": labels,
+            "props": props,
+            "identifiers": identifiers,
+        }
+
+        return {
+            "id": id,
+            "scheme": "GEMET",
+            "subject": labels.get("en", "").capitalize(),
+            "title": labels,
+            "props": props,
+            "identifiers": identifiers,
+        }
+
+    def apply(self, stream_entry, *args, **kwargs):
+        """Transform a stream entry to the required dictionary format.
+
+        :param stream_entry: The entry to be transformed, which includes the subject and the RDF graph.
+        :return: The transformed stream entry.
+        """
+        # Apply transformations
+        entry_data = self._transform_entry(
+            stream_entry.entry["subject"], stream_entry.entry["rdf_graph"]
+        )
+        stream_entry.entry = entry_data
+        return stream_entry
+
+
+# Configuration for datastream readers, transformers, and writers
+VOCABULARIES_DATASTREAM_READERS = {"gemet-reader": GEMETSubjectsHTTPReader}
+
+VOCABULARIES_DATASTREAM_WRITERS = {}
+
+VOCABULARIES_DATASTREAM_TRANSFORMERS = {
+    "gemet-transformer": GEMETSubjectsTransformer
+}
+
+DATASTREAM_CONFIG = {
+    "readers": [
+        {
+            "type": "gemet-reader",
+        }
+    ],
+    "transformers": [{"type": "gemet-transformer"}],
+    "writers": [
+        {
+            "type": "subjects-service",
+        }
+    ],
+}

--- a/invenio_vocabularies/contrib/subjects/jsonschemas/subjects/subject-v1.0.0.json
+++ b/invenio_vocabularies/contrib/subjects/jsonschemas/subjects/subject-v1.0.0.json
@@ -34,9 +34,20 @@
       "type": "object",
       "patternProperties": {
         "^.*$": {
-          "type": "string"
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "identifiers": {
       "description": "Alternate identifiers for the subject.",

--- a/tests/contrib/subjects/euroscivoc/test_subjects_euroscivoc_datastream.py
+++ b/tests/contrib/subjects/euroscivoc/test_subjects_euroscivoc_datastream.py
@@ -1,16 +1,21 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
 import io
-import unittest
-from unittest.mock import Mock, patch
 
 import pytest
-from rdflib import RDF, Graph, Namespace, URIRef
+from rdflib import RDF, Graph
 
 from invenio_vocabularies.contrib.subjects.euroscivoc.datastreams import (
-    EuroSciVocSubjectsHTTPReader,
     EuroSciVocSubjectsTransformer,
 )
 from invenio_vocabularies.datastreams.datastreams import StreamEntry
-from invenio_vocabularies.datastreams.errors import ReaderError, TransformerError
+from invenio_vocabularies.datastreams.readers import RDFReader
 
 XML_DATA_PREF_LABEL = bytes(
     """<?xml version="1.0" encoding="UTF-8"?>
@@ -159,7 +164,7 @@ def expected_from_rdf_alt_label_without_parent():
 def test_euroscivoc_subjects_transformer_pref_label(
     expected_from_rdf_pref_label_with_parent,
 ):
-    reader = EuroSciVocSubjectsHTTPReader()
+    reader = RDFReader()
     rdf_data = io.BytesIO(XML_DATA_PREF_LABEL)
     rdf_graph = Graph()
     rdf_graph.parse(rdf_data, format="xml")
@@ -176,7 +181,7 @@ def test_euroscivoc_subjects_transformer_pref_label(
 def test_euroscivoc_subjects_transformer_alt_label(
     expected_from_rdf_alt_label_without_parent,
 ):
-    reader = EuroSciVocSubjectsHTTPReader()
+    reader = RDFReader()
     rdf_data = io.BytesIO(XML_DATA_ALT_LABEL)
     rdf_graph = Graph()
     rdf_graph.parse(rdf_data, format="xml")

--- a/tests/contrib/subjects/gemet/test_subjects_gemet_datastream.py
+++ b/tests/contrib/subjects/gemet/test_subjects_gemet_datastream.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 CERN.
+#
+# Invenio-Vocabularies is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+import io
+
+import pytest
+from rdflib import RDF, Graph
+
+from invenio_vocabularies.contrib.subjects.gemet.datastreams import (
+    GEMETSubjectsTransformer,
+)
+from invenio_vocabularies.datastreams.datastreams import StreamEntry
+from invenio_vocabularies.datastreams.readers import RDFReader
+
+XML_DATA = bytes(
+    """<?xml version="1.0" encoding="UTF-8"?>
+    <rdf:RDF xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:dcterms="http://purl.org/dc/terms/"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+         xml:base="http://www.eionet.europa.eu/gemet/">
+    <skos:Concept rdf:about="concept/10008">
+        <skos:inScheme rdf:resource="http://www.eionet.europa.eu/gemet/gemetThesaurus"/>
+        <skos:prefLabel xml:lang="en">Consumer product</skos:prefLabel>
+        <skos:prefLabel xml:lang="ar">منتج استهلاكي</skos:prefLabel>
+        <skos:broader rdf:resource="concept/6660"/>
+        <skos:memberOf rdf:resource="group/10112"/>
+        <skos:memberOf rdf:resource="theme/27"/>
+        <skos:memberOf rdf:resource="theme/34"/>
+    </skos:Concept>
+    <rdf:Description rdf:about="theme/27">
+        <skos:member rdf:resource="concept/10008"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="theme/34">
+        <skos:member rdf:resource="concept/10008"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="group/10112">
+        <skos:member rdf:resource="concept/10008"/>
+    </rdf:Description>
+    </rdf:RDF>""",
+    encoding="utf-8",
+)
+
+
+@pytest.fixture(scope="module")
+def expected_from_rdf():
+    return [
+        {
+            "id": "gemet:concept/10008",
+            "scheme": "GEMET",
+            "subject": "Consumer product",
+            "title": {
+                "en": "Consumer product",
+                "ar": "منتج استهلاكي",
+            },
+            "props": {
+                "parents": "gemet:concept/6660",
+                "groups": ["http://www.eionet.europa.eu/gemet/group/10112"],
+                "themes": [
+                    "http://www.eionet.europa.eu/gemet/theme/27",
+                    "http://www.eionet.europa.eu/gemet/theme/34",
+                ],
+            },
+            "identifiers": [
+                {
+                    "scheme": "url",
+                    "identifier": "http://www.eionet.europa.eu/gemet/concept/10008",
+                }
+            ],
+        }
+    ]
+
+
+def test_gemet_concept_transformer_pref_label(expected_from_rdf):
+    reader = RDFReader()
+    rdf_data = io.BytesIO(XML_DATA)
+    rdf_graph = Graph()
+    rdf_graph.parse(rdf_data, format="xml")
+    stream_entries = list(reader._iter(rdf_graph))
+    assert len(stream_entries) > 0
+    transformer = GEMETSubjectsTransformer()
+    result = []
+    for entry in stream_entries:
+        entry = transformer.apply(StreamEntry(entry)).entry
+        result.append(entry)
+    assert expected_from_rdf == result


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Closes Issue https://github.com/inveniosoftware/invenio-vocabularies/issues/434
Adding a new hierarchal vocabulary [GEMET](https://www.eionet.europa.eu/gemet/en/about/)
<img width="400" alt="Screenshot 2024-11-20 at 10 23 22" src="https://github.com/user-attachments/assets/eff6b3a0-8e84-4325-a7ba-18e7239fddc7">
<img width="946" alt="Screenshot 2024-11-20 at 10 23 31" src="https://github.com/user-attachments/assets/8cbfd917-dc2e-421f-986c-e958833719d0">

**/api/subjects**
```json=
{
                "id": "gemet:concept/11",
                "created": "2024-11-19T15:41:32.341318+00:00",
                "updated": "2024-11-19T15:41:32.354614+00:00",
                "links": {
                    "self": "https://127.0.0.1:5000/api/subjects/gemet%3Aconcept%2F11"
                },
                "revision_id": 1,
                "title": {
                    "ar": "عامل لاحيوي",
                    "az": "Abiotik amil",
                    "bg": "Абиотичен фактор",
                    "ca": "Factor abiòtic",
                    "cs": "Činitel abiotický",
                    "da": "Abiotiske faktorer",
                    "de": "Abiotischer faktor",
                    "el": "Αβιοτικός παράγοντας",
                    "en": "Abiotic factor",
                    "es": "Factor abiótico",
                    "et": "Abiootiline tegur",
                    "eu": "Faktore abiotiko",
                    "fi": "Abioottinen tekijä",
                    "fr": "Facteur abiotique",
                    "ga": "Toisc aibitheach",
                    "hr": "Abiotički čimbenik",
                    "hu": "Abiotikus tényező",
                    "hy": "Աբիոտիկ գործոն",
                    "is": "Ólífrænn þáttur",
                    "it": "Fattore abiotico",
                    "ka": "აბიოტური ფაქტორი",
                    "lt": "Abiotinis veiksnys",
                    "lv": "Abiotisks faktors",
                    "mt": "Fattur abijotiku",
                    "nl": "Abiotische factor",
                    "no": "Abiotisk faktor",
                    "pl": "Abiotyczny czynnik",
                    "pt": "Factores abióticos",
                    "ro": "Factor abiotic",
                    "ru": "Абиотический фактор",
                    "sk": "Abiotický faktor",
                    "sl": "Abiotski dejavnik",
                    "sv": "Abiotisk faktor",
                    "tr": "Abiyotik faktör",
                    "uk": "Абіотичний фактор"
                },
                "scheme": "GEMET",
                "subject": "Abiotic factor",
                "props": {
                    "parents": "gemet:concept/7472,gemet:concept/5524,gemet:concept/4805,gemet:concept/892,gemet:concept/2470,gemet:concept/2457",
                    "groups": [
                        "http://www.eionet.europa.eu/gemet/group/893"
                    ],
                    "themes": [
                        "http://www.eionet.europa.eu/gemet/theme/4"
                    ]
                },
                "identifiers": [
                    {
                        "identifier": "http://www.eionet.europa.eu/gemet/concept/11",
                        "scheme": "url"
                    }
                ]
            }

```

import GEMET
```python=
from invenio_vocabularies.contrib.subjects.config import gemet_file_url
from invenio_vocabularies.datastreams import DataStreamFactory
config={'readers': [{'type': 'http', 
                                "args": {"origin": gemet_file_url, }},
                                {"type": "gzip"},
                                {'type': 'rdf'}], 
            'writers': [{'args': {'writer': {'type': 'subjects-service'}},
                'type': 'async'}],
              'transformers': [{'type': 'gemet-transformer'}]}
 
data_stream = DataStreamFactory.create(
     readers_config=config["readers"],
     transformers_config=config.get("transformers"),
     writers_config=config["writers"],)
 
for result in data_stream.process():
   print(result.entry)
```


import EuroSciVoc
```python=
from invenio_vocabularies.contrib.subjects.config import euroscivoc_file_url
from invenio_vocabularies.datastreams import DataStreamFactory
config={'readers': [{'type': 'http',
            "args": { "origin": euroscivoc_file_url,}},
            {'type': 'rdf'}], 
         'writers': [{'args': {'writer': {'type': 'subjects-service'}},
         'type': 'async'}],
         'transformers': [{'type': 'euroscivoc-transformer'}]}

data_stream = DataStreamFactory.create(
    readers_config=config["readers"],
    transformers_config=config.get("transformers"),
    writers_config=config["writers"],
)

for result in data_stream.process():
    print(result.entry)
```

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
