### PR TITLE
names: link affiliations IDs from ORCiD parsing

### DIFF
--- a/invenio_vocabularies/config.py
+++ b/invenio_vocabularies/config.py
@@ -213,3 +213,16 @@ VOCABULARIES_ORCID_SYNC_SINCE = {
     "days": 1,
 }
 """ORCID time shift to sync. Parameters accepted are the ones passed to 'datetime.timedelta'."""
+
+VOCABULARIES_ORCID_ORG_IDS_MAPPING_PATH = None
+"""Path to the CSV file for mapping ORCiD organization IDs to affiliation IDs.
+
+The path can be specified as either an absolute path or a relative path within the
+Flask app instance folder (i.e. ``current_app.instance_path``).
+
+The CSV file should have the following columns:
+
+- `org_scheme`: The ORCiD organization ID.
+- `org_id`: The ORCiD organization ID.
+- `aff_id`: The affiliation ID to map to.
+"""

--- a/invenio_vocabularies/contrib/names/datastreams.py
+++ b/invenio_vocabularies/contrib/names/datastreams.py
@@ -260,15 +260,12 @@ class OrcidTransformer(BaseTransformer):
                 employment.get("employment-summary", {}) for employment in employments
             ]
 
-            history = set()
             for employment in employments:
                 terminated = employment.get("end-date")
-                org = employment["organization"]
-
-                if terminated or org["name"] in history:
+                if terminated:
                     continue
 
-                history.add(org["name"])
+                org = employment["organization"]
                 aff = {"name": org["name"]}
 
                 # Extract the org ID, to link to the affiliation vocabulary
@@ -276,7 +273,8 @@ class OrcidTransformer(BaseTransformer):
                 if aff_id:
                     aff["id"] = aff_id
 
-                result.append(aff)
+                if aff not in result:
+                    result.append(aff)
         except Exception:
             pass
         return result

--- a/invenio_vocabularies/contrib/names/datastreams.py
+++ b/invenio_vocabularies/contrib/names/datastreams.py
@@ -266,15 +266,23 @@ class OrcidTransformer(BaseTransformer):
                     continue
 
                 org = employment["organization"]
-                aff = {"name": org["name"]}
-
-                # Extract the org ID, to link to the affiliation vocabulary
                 aff_id = self._extract_affiliation_id(org)
+
+                # Skip adding if the ID already exists in result
+                if aff_id and any(aff.get("id") == aff_id for aff in result):
+                    continue
+
+                # Skip adding if the name exists in result with no ID
+                if any(
+                    aff.get("name") == org["name"] and "id" not in aff for aff in result
+                ):
+                    continue
+
+                aff = {"name": org["name"]}
                 if aff_id:
                     aff["id"] = aff_id
 
-                if aff not in result:
-                    result.append(aff)
+                result.append(aff)
         except Exception:
             pass
         return result

--- a/invenio_vocabularies/contrib/names/datastreams.py
+++ b/invenio_vocabularies/contrib/names/datastreams.py
@@ -50,8 +50,7 @@ class OrcidDataSyncReader(BaseReader):
         try:
             return self.s3_client.read_file(f"s3://{bucket}/{key}")
         except Exception:
-            # TODO: log
-            return None
+            current_app.logger.exception("Failed to fetch ORCiD record.")
 
     def _process_lambda_file(self, fileobj):
         """Process the ORCiD lambda file and returns a list of ORCiDs to sync.

--- a/tests/contrib/names/test_names_datastreams.py
+++ b/tests/contrib/names/test_names_datastreams.py
@@ -8,6 +8,8 @@
 
 """Names data streams tests."""
 
+import os
+import tempfile
 from copy import deepcopy
 from unittest.mock import patch
 
@@ -23,6 +25,7 @@ from invenio_vocabularies.contrib.names.datastreams import (
 )
 from invenio_vocabularies.datastreams import StreamEntry
 from invenio_vocabularies.datastreams.errors import TransformerError, WriterError
+from invenio_vocabularies.datastreams.transformers import XMLTransformer
 
 
 @pytest.fixture(scope="function")
@@ -43,17 +46,8 @@ def name_full_data():
     }
 
 
-@pytest.fixture(scope="module")
-def expected_from_xml():
-    return {
-        "id": "0000-0001-8135-3489",
-        "given_name": "Lars Holm",
-        "family_name": "Nielsen",
-        "identifiers": [{"scheme": "orcid", "identifier": "0000-0001-8135-3489"}],
-        "affiliations": [{"id": "01ggx4157", "name": "CERN"}],
-    }
-
-
+# NOTE: This is a simplified version of the original XML data from ORCiD. Sections like
+#       works, funding, educations, etc. and attributes have been removed.
 XML_ENTRY_DATA = b"""
 <record:record>
     <common:orcid-identifier>
@@ -66,7 +60,6 @@ XML_ENTRY_DATA = b"""
             <personal-details:given-names>Lars Holm</personal-details:given-names>
             <personal-details:family-name>Nielsen</personal-details:family-name>
         </person:name>
-        <other-name:other-names>
     </person:person>
     <activities:activities-summary>
         <activities:employments>
@@ -90,6 +83,21 @@ XML_ENTRY_DATA = b"""
             <activities:affiliation-group>
                 <employment:employment-summary>
                     <common:start-date>
+                        <common:year>2024</common:year>
+                        <common:month>01</common:month>
+                    </common:start-date>
+                    <common:organization>
+                        <common:name>ACME Inc.</common:name>
+                        <common:disambiguated-organization>
+                            <common:disambiguated-organization-identifier>grid.123456.z</common:disambiguated-organization-identifier>
+                            <common:disambiguation-source>GRID</common:disambiguation-source>
+                        </common:disambiguated-organization>
+                    </common:organization>
+                </employment:employment-summary>
+            </activities:affiliation-group>
+            <activities:affiliation-group>
+                <employment:employment-summary >
+                    <common:start-date>
                         <common:year>2007</common:year>
                         <common:month>08</common:month>
                     </common:start-date>
@@ -100,22 +108,53 @@ XML_ENTRY_DATA = b"""
                     <common:organization>
                         <common:name>European Southern Observatory</common:name>
                         <common:disambiguated-organization>
-                            <common:disambiguated-organization-identifier>54249</common:disambiguated-organization-identifier>
-                            <common:disambiguation-source>RINGGOLD</common:disambiguation-source>
+                            <common:disambiguated-organization-identifier>grid.424907.c</common:disambiguated-organization-identifier>
+                            <common:disambiguation-source>GRID</common:disambiguation-source>
                         </common:disambiguated-organization>
                     </common:organization>
                 </employment:employment-summary>
             </activities:affiliation-group>
         </activities:employments>
     </activities:activities-summary>
-<record:record>
+</record:record>
 """
 
-
-@pytest.fixture(scope="function")
-def bytes_xml_data():
-    # simplified version of an XML file of the ORCiD dump
-    return XML_ENTRY_DATA
+XML_ENTRY_DATA_SINGLE_EMPLOYMENT = b"""
+<record:record>
+    <common:orcid-identifier>
+        <common:uri>https://orcid.org/0000-0001-8135-3489</common:uri>
+        <common:path>0000-0001-8135-3489</common:path>
+        <common:host>orcid.org</common:host>
+    </common:orcid-identifier>
+    <person:person>
+        <person:name>
+            <personal-details:given-names>Lars Holm</personal-details:given-names>
+            <personal-details:family-name>Nielsen</personal-details:family-name>
+        </person:name>
+    </person:person>
+    <activities:activities-summary>
+        <activities:employments>
+            <activities:affiliation-group>
+                <employment:employment-summary>
+                    <common:start-date>
+                        <common:year>2012</common:year>
+                        <common:month>03</common:month>
+                        <common:day>16</common:day>
+                    </common:start-date>
+                    <common:organization>
+                        <common:name>CERN</common:name>
+                        <common:disambiguated-organization>
+                            <common:disambiguated-organization-identifier>https://ror.org/01ggx4157
+</common:disambiguated-organization-identifier>
+                            <common:disambiguation-source>ROR</common:disambiguation-source>
+                        </common:disambiguated-organization>
+                    </common:organization>
+                </employment:employment-summary>
+            </activities:affiliation-group>
+        </activities:employments>
+    </activities:activities-summary>
+</record:record>
+"""
 
 
 NAMES_TEST = {
@@ -128,77 +167,192 @@ NAMES_TEST = {
 
 
 @pytest.fixture(scope="function")
-def dict_xml_entry():
-    return StreamEntry(
+def orcid_data():
+    base = {
+        "orcid-identifier": {
+            "uri": "https://orcid.org/0000-0001-8135-3489",
+            "path": "0000-0001-8135-3489",
+            "host": "orcid.org",
+        },
+        "person": {
+            "name": {"given-names": "Lars Holm", "family-name": "Nielsen"},
+        },
+    }
+
+    employments = [
         {
-            "orcid-identifier": {
-                "uri": "https://orcid.org/0000-0001-8135-3489",
-                "path": "0000-0001-8135-3489",
-                "host": "orcid.org",
-            },
-            "person": {
-                "name": {
-                    "given-names": "Lars Holm",
-                    "family-name": "Nielsen",
-                    "@visibility": "public",
-                    "@path": "0000-0001-8135-3489",
-                },
-                "external-identifiers": {
-                    "@path": "/0000-0001-8135-3489/external-identifiers"
-                },
-                "@path": "/0000-0001-8135-3489/person",
-            },
-            "activities-summary": {
-                "employments": {
-                    "affiliation-group": {
-                        "employment-summary": {
-                            "organization": {
-                                "name": "CERN",
-                                "disambiguated-organization": {
-                                    "disambiguated-organization-identifier": "https://ror.org/01ggx4157",
-                                    "disambiguation-source": "ROR",
-                                },
-                            }
-                        }
+            "employment-summary": {
+                "organization": {
+                    "name": "CERN",
+                    "disambiguated-organization": {
+                        "disambiguated-organization-identifier": "https://ror.org/01ggx4157",
+                        "disambiguation-source": "ROR",
                     },
-                    "@path": "/0000-0001-8135-3489/employments",
                 },
-                "@path": "/0000-0001-8135-3489/activities",
+                "start-date": {"year": "2012", "month": "03", "day": "16"},
+            }
+        },
+        {
+            "employment-summary": {
+                "organization": {
+                    "name": "ACME Inc.",
+                    "disambiguated-organization": {
+                        "disambiguated-organization-identifier": "grid.123456.z",
+                        "disambiguation-source": "GRID",
+                    },
+                },
+                "start-date": {"year": "2024", "month": "01"},
+            }
+        },
+        {
+            "employment-summary": {
+                "organization": {
+                    "name": "European Southern Observatory",
+                    "disambiguated-organization": {
+                        "disambiguated-organization-identifier": "grid.424907.c",
+                        "disambiguation-source": "GRID",
+                    },
+                },
+                "start-date": {"year": "2007", "month": "08"},
+                "end-date": {"year": "2012", "month": "03"},
             },
-            "@path": "/0000-0001-8135-3489",
-        }
-    )
+        },
+    ]
+
+    return {
+        "xml": {
+            "multi_employment": XML_ENTRY_DATA,
+            "single_employment": XML_ENTRY_DATA_SINGLE_EMPLOYMENT,
+        },
+        "json": {
+            "multi_employment": {
+                **base,
+                "activities-summary": {
+                    "employments": {"affiliation-group": employments},
+                },
+            },
+            "single_employment": {
+                **base,
+                "activities-summary": {
+                    # NOTE: Because the XML data has only one employment, the
+                    # transformer will not create a list of employments, but instead a
+                    # single employment object.
+                    "employments": {"affiliation-group": employments[0]}
+                },
+            },
+        },
+    }
 
 
-def test_orcid_transformer(dict_xml_entry, expected_from_xml):
+@pytest.fixture(scope="module")
+def expected_from_xml():
+    base = {
+        "id": "0000-0001-8135-3489",
+        "given_name": "Lars Holm",
+        "family_name": "Nielsen",
+        "identifiers": [{"scheme": "orcid", "identifier": "0000-0001-8135-3489"}],
+    }
+
+    return {
+        "multi_employment": {
+            **base,
+            "affiliations": [
+                {"id": "01ggx4157", "name": "CERN"},
+                # NOTE: GRID identifiers do not result in linked affiliations
+                {"name": "ACME Inc."},
+                # NOTE: terminated employments are not included in the affiliations
+            ],
+        },
+        "single_employment": {
+            **base,
+            "affiliations": [{"id": "01ggx4157", "name": "CERN"}],
+        },
+    }
+
+
+@pytest.fixture(scope="function")
+def org_ids_mapping_file_config(app):
+    """ORCiD organization IDs mappings CSV file."""
+    fout = tempfile.NamedTemporaryFile(mode="w", delete=False)
+    fout.write('"GRID","grid.123456.z","acme_inc_id"\n')
+    fout.close()
+
+    old_config = app.config.get("VOCABULARIES_ORCID_ORG_IDS_MAPPING_PATH")
+    app.config["VOCABULARIES_ORCID_ORG_IDS_MAPPING_PATH"] = fout.name
+    yield
+
+    app.config["VOCABULARIES_ORCID_ORG_IDS_MAPPING_PATH"] = old_config
+    os.unlink(fout.name)
+
+
+def test_orcid_xml_transform(orcid_data):
+    """Test XML transformer with ORCiD record.
+
+    NOTE: this might look somewhat "redundant", since we're again testing if the
+    XMLTransformer works as expected. However, this is a more specific test
+    that demonstrates how the transformer behaves with more complex XML data, that
+    can have e.g. nested elements that can be arrays or objects.
+    """
+    xml_data = orcid_data["xml"]
+    json_data = orcid_data["json"]
+
+    for key, data in xml_data.items():
+        transformer = XMLTransformer(root_element="record")
+        transform_result = transformer.apply(StreamEntry(data)).entry
+        assert transform_result == json_data[key]
+
+
+def test_orcid_transformer(app, orcid_data, expected_from_xml):
+    """Test ORCiD transformer data."""
     transformer = OrcidTransformer()
-    assert expected_from_xml == transformer.apply(dict_xml_entry).entry
+    input_data = orcid_data["json"]
+
+    for key, data in input_data.items():
+        assert expected_from_xml[key] == transformer.apply(StreamEntry(data)).entry, key
+
+
+def test_orcid_transformer_org_ids_mapping_from_file(
+    app,
+    orcid_data,
+    expected_from_xml,
+    org_ids_mapping_file_config,
+):
+    """Test ORCiD transformer data with org IDs mapping file."""
+    transformer = OrcidTransformer()
+    input_data = orcid_data["json"]["multi_employment"]
+    expected = deepcopy(expected_from_xml["multi_employment"])
+    expected["affiliations"] = [
+        {"id": "01ggx4157", "name": "CERN"},
+        {"id": "acme_inc_id", "name": "ACME Inc."},
+    ]
+
+    assert expected == transformer.apply(StreamEntry(input_data)).entry
 
 
 @pytest.mark.parametrize("name,is_valid_name", NAMES_TEST.items())
-def test_orcid_transformer_name_filtering(dict_xml_entry, name, is_valid_name):
+def test_orcid_transformer_name_filtering(orcid_data, name, is_valid_name):
     transformer = OrcidTransformer()
-    val = deepcopy(dict_xml_entry)
+    val = deepcopy(orcid_data["json"]["multi_employment"])
     if is_valid_name:
-        assert transformer.apply(val).entry
+        assert transformer.apply(StreamEntry(val)).entry
     else:
         with pytest.raises(TransformerError):
-            val.entry["person"]["name"]["given-names"] = name
-            val.entry["person"]["name"]["family-name"] = ""
-            transformer.apply(val)
+            val["person"]["name"]["given-names"] = name
+            val["person"]["name"]["family-name"] = ""
+            transformer.apply(StreamEntry(val))
         with pytest.raises(TransformerError):
-            val.entry["person"]["name"]["given-names"] = ""
-            val.entry["person"]["name"]["family-name"] = name
-            transformer.apply(val)
+            val["person"]["name"]["given-names"] = ""
+            val["person"]["name"]["family-name"] = name
+            transformer.apply(StreamEntry(val))
 
 
 @pytest.mark.parametrize("name", NAMES_TEST.keys())
-def test_orcid_transformer_different_names_no_regex(dict_xml_entry, name):
+def test_orcid_transformer_different_names_no_regex(orcid_data, name):
     transformer = OrcidTransformer(names_exclude_regex=None)
-    val = deepcopy(dict_xml_entry)
-    val.entry["person"]["name"]["given-names"] = name
-    val.entry["person"]["name"]["family-name"] = ""
-    assert transformer.apply(val).entry
+    val = deepcopy(orcid_data["json"]["multi_employment"])
+    val["person"]["name"]["given-names"] = name
+    val["person"]["name"]["family-name"] = ""
+    assert transformer.apply(StreamEntry(val)).entry
 
 
 class MockResponse:
@@ -207,14 +361,14 @@ class MockResponse:
 
 
 @patch("requests.get", side_effect=lambda url, headers: MockResponse())
-def test_orcid_http_reader(_, bytes_xml_data):
+def test_orcid_http_reader(_):
     reader = OrcidHTTPReader(id="0000-0001-8135-3489")
     results = []
     for entry in reader.read():
         results.append(entry)
 
     assert len(results) == 1
-    assert bytes_xml_data == results[0]
+    assert XML_ENTRY_DATA == results[0]
 
 
 def test_names_service_writer_create(app, db, search_clear, name_full_data):

--- a/tests/contrib/names/test_names_datastreams.py
+++ b/tests/contrib/names/test_names_datastreams.py
@@ -240,6 +240,12 @@ def orcid_data():
                     "employments": {"affiliation-group": employments[0]}
                 },
             },
+            "duplicate_affiliations": {
+                **base,
+                "activities-summary": {
+                    "employments": {"affiliation-group": employments + employments},
+                },
+            },
         },
     }
 
@@ -266,6 +272,14 @@ def expected_from_xml():
         "single_employment": {
             **base,
             "affiliations": [{"id": "01ggx4157", "name": "CERN"}],
+        },
+        "duplicate_affiliations": {
+            **base,
+            "affiliations": [
+                # Affiliations are deduplicated
+                {"id": "01ggx4157", "name": "CERN"},
+                {"name": "ACME Inc."},
+            ],
         },
     }
 

--- a/tests/datastreams/test_transformers.py
+++ b/tests/datastreams/test_transformers.py
@@ -18,26 +18,51 @@ from invenio_vocabularies.datastreams.transformers import XMLTransformer
 @pytest.fixture(scope="module")
 def expected_from_xml():
     return {
-        "record": {
-            "field_one": "value",
-            "multi_field": {"some": "value", "another": "value too"},
-        }
+        "top_level_field": "top-level single value",
+        "top_level_object_field": {
+            "some": "value",
+            "another": "value too",
+            "nested_array_field": {
+                "@array_attr": "value",
+                "array_element_object": [
+                    {
+                        "@obj_attr": "first",
+                        "element_foo": "value1",
+                        "element_bar": "value1",
+                    },
+                    {
+                        "@obj_attr": "second",
+                        "element_foo": "value2",
+                        "element_bar": "value2",
+                        "element_qux": "value2",
+                    },
+                ],
+            },
+        },
     }
 
 
 def test_xml_transformer(expected_from_xml):
     bytes_xml_entry = StreamEntry(
-        bytes(
-            '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n'
-            "<record:record>\n"
-            "    <field_one:field_one>value</field_one:field_one>\n"
-            "    <multi_field:multi_field>\n"
-            "        <some:some>value</some:some>\n"
-            "        <another:another>value too</another:another>\n"
-            "    </multi_field:multi_field>\n"
-            "</record:record>\n",
-            encoding="raw_unicode_escape",
-        )
+        b"""
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <ns:top_level_field>top-level single value</ns:top_level_field>
+        <ns:top_level_object_field>
+            <ns:some>value</ns:some>
+            <ns:another>value too</ns:another>
+            <ns:nested_array_field array_attr="value">
+                <ns:array_element_object obj_attr="first">
+                    <ns:element_foo>value1</ns:element_foo>
+                    <ns:element_bar>value1</ns:element_bar>
+                </ns:array_element_object>
+                <ns:array_element_object obj_attr="second">
+                    <ns:element_foo>value2</ns:element_foo>
+                    <ns:element_bar>value2</ns:element_bar>
+                    <ns:element_qux>value2</ns:element_qux>
+                </ns:array_element_object>
+            </ns:nested_array_field array_attr="value">
+        </ns:top_level_object_field>
+        """
     )
 
     transformer = XMLTransformer()
@@ -46,15 +71,25 @@ def test_xml_transformer(expected_from_xml):
 
 def test_bad_xml_transformer():
     bytes_xml_entry = StreamEntry(
-        bytes(
-            '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n'
-            "<field_one:field_one>value</field_one:field_one>\n"
-            "<multi_field:multi_field>\n"
-            "    <some:some>value</some:some>\n"
-            "    <another:another>value too</another:another>\n"
-            "</multi_field:multi_field>\n",
-            encoding="raw_unicode_escape",
-        )
+        b"""
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <ns:top_level_field>top-level single value</ns:top_level_field>
+        <ns:top_level_object_field>
+            <ns:some>value</ns:some>
+            <ns:another>value too</ns:another>
+            <ns:nested_array_field array_attr="value">
+                <ns:array_element_object obj_attr="first">
+                    <ns:element_foo>value1</ns:element_foo>
+                    <ns:element_bar>value1</ns:element_bar>
+                </ns:array_element_object>
+                <ns:array_element_object obj_attr="second">
+                    <ns:element_foo>value2</ns:element_foo>
+                    <ns:element_bar>value2</ns:element_bar>
+                    <ns:element_qux>value2</ns:element_qux>
+                </ns:array_element_object>
+            </ns:nested_array_field array_attr="value">
+        </ns:top_level_object_field>
+        """
     )
 
     transformer = XMLTransformer(root_element="field_two")


### PR DESCRIPTION
- Closes #442.
- **names: extract affiliation identifiers from employments**
- **names: support mapping ORCiD org IDs to linked affiliation IDs**