### PR TITLE
Improve search accuracy for names, affiliations, funders

### DIFF
--- a/invenio_vocabularies/contrib/funders/config.py
+++ b/invenio_vocabularies/contrib/funders/config.py
@@ -13,7 +13,9 @@ from invenio_i18n import get_locale
 from invenio_i18n import lazy_gettext as _
 from invenio_records_resources.services import SearchOptions
 from invenio_records_resources.services.records.components import DataComponent
-from invenio_records_resources.services.records.params import SuggestQueryParser
+from invenio_records_resources.services.records.queryparser import (
+    CompositeSuggestQueryParser,
+)
 from werkzeug.local import LocalProxy
 
 from ...services.components import ModelPIDComponent
@@ -23,24 +25,29 @@ funder_schemes = LocalProxy(lambda: current_app.config["VOCABULARIES_FUNDER_SCHE
 funder_fundref_doi_prefix = LocalProxy(
     lambda: current_app.config["VOCABULARIES_FUNDER_DOI_PREFIX"]
 )
-localized_title = LocalProxy(lambda: f"title.{get_locale()}^20")
+localized_title = LocalProxy(lambda: f"title.{get_locale()}^2")
 
 
 class FundersSearchOptions(SearchOptions):
     """Search options."""
 
-    suggest_parser_cls = SuggestQueryParser.factory(
+    suggest_parser_cls = CompositeSuggestQueryParser.factory(
         fields=[
-            "name^100",
-            "acronym.keyword^100",
-            "acronym^40",
+            # We boost the acronym fields, since they're smaller words and are more
+            # likely to be used in a query.
+            "acronym.keyword^50",
+            "acronym^10",
+            "name^10",
+            # Aliases can sometimes be shorter, so we boost them a bit.
+            "aliases^5",
             localized_title,
-            "id^20",
-            "aliases^20",
-            "identifiers.identifier^10",
-        ],
-        type="most_fields",  # https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html#multi-match-types
-        fuzziness="AUTO",  # https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#fuzziness
+            "id^2",
+            # Allow to search identifiers directly (e.g. ROR)
+            "identifiers.identifier",
+            "country",
+            "country_name",
+            "types",
+        ]
     )
 
     sort_default = "bestmatch"

--- a/invenio_vocabularies/contrib/names/config.py
+++ b/invenio_vocabularies/contrib/names/config.py
@@ -15,7 +15,9 @@ from invenio_records_resources.services.records.components import (
     DataComponent,
     RelationsComponent,
 )
-from invenio_records_resources.services.records.params import SuggestQueryParser
+from invenio_records_resources.services.records.queryparser import (
+    CompositeSuggestQueryParser,
+)
 from werkzeug.local import LocalProxy
 
 from ...services.components import PIDComponent
@@ -26,16 +28,17 @@ names_schemes = LocalProxy(lambda: current_app.config["VOCABULARIES_NAMES_SCHEME
 class NamesSearchOptions(SearchOptions):
     """Search options."""
 
-    suggest_parser_cls = SuggestQueryParser.factory(
+    suggest_parser_cls = CompositeSuggestQueryParser.factory(
         fields=[
-            "given_name^100",
-            "name^70",
-            "family_name^50",
-            "identifiers.identifier^20",
-            "affiliations.name^20",
+            "name^5",
+            # We boost the affiliation acronym fields, since they're short and more
+            # likely to be used in a query.
+            "affiliations.acronym.keyword^3",
+            "affiliations.acronym",
+            "affiliations.name",
+            # Allow to search identifiers directly (e.g. ORCID)
+            "identifiers.identifier",
         ],
-        type="most_fields",  # https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html#multi-match-types
-        fuzziness="AUTO",
     )
 
     sort_default = "bestmatch"

--- a/invenio_vocabularies/contrib/names/mappings/os-v1/names/name-v2.0.0.json
+++ b/invenio_vocabularies/contrib/names/mappings/os-v1/names/name-v2.0.0.json
@@ -125,6 +125,17 @@
             "type": "text",
             "analyzer": "accent_edge_analyzer",
             "search_analyzer": "accent_analyzer"
+          },
+          "acronym": {
+            "type": "text",
+            "analyzer": "accent_edge_analyzer",
+            "search_analyzer": "accent_analyzer",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "normalizer": "accent_normalizer"
+              }
+            }
           }
         }
       },

--- a/invenio_vocabularies/contrib/names/mappings/os-v2/names/name-v2.0.0.json
+++ b/invenio_vocabularies/contrib/names/mappings/os-v2/names/name-v2.0.0.json
@@ -125,6 +125,17 @@
             "type": "text",
             "analyzer": "accent_edge_analyzer",
             "search_analyzer": "accent_analyzer"
+          },
+          "acronym": {
+            "type": "text",
+            "analyzer": "accent_edge_analyzer",
+            "search_analyzer": "accent_analyzer",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "normalizer": "accent_normalizer"
+              }
+            }
           }
         }
       },

--- a/invenio_vocabularies/contrib/names/names.py
+++ b/invenio_vocabularies/contrib/names/names.py
@@ -30,7 +30,7 @@ from .schema import NameSchema
 name_relations = RelationsField(
     affiliations=PIDListRelation(
         "affiliations",
-        keys=["name"],
+        keys=["name", "acronym"],
         pid_field=Affiliation.pid,
         cache_key="affiliations",
     )

--- a/invenio_vocabularies/contrib/names/schema.py
+++ b/invenio_vocabularies/contrib/names/schema.py
@@ -16,8 +16,16 @@ from marshmallow_utils.fields import IdentifierSet, SanitizedUnicode
 from marshmallow_utils.schemas import IdentifierSchema
 
 from ...services.schema import BaseVocabularySchema, ModePIDFieldVocabularyMixin
-from ..affiliations.schema import AffiliationRelationSchema
+from ..affiliations.schema import (
+    AffiliationRelationSchema as BaseAffiliationRelationSchema,
+)
 from .config import names_schemes
+
+
+class AffiliationRelationSchema(BaseAffiliationRelationSchema):
+    """Affiliation relation schema."""
+
+    acronym = SanitizedUnicode(dump_only=True)
 
 
 class NameSchema(BaseVocabularySchema, ModePIDFieldVocabularyMixin):

--- a/invenio_vocabularies/services/config.py
+++ b/invenio_vocabularies/services/config.py
@@ -14,17 +14,11 @@ from flask import current_app
 from invenio_i18n import lazy_gettext as _
 from invenio_records_resources.services import (
     Link,
-    LinksTemplate,
-    RecordService,
     RecordServiceConfig,
     SearchOptions,
     pagination_links,
 )
-from invenio_records_resources.services.base import (
-    ConditionalLink,
-    Service,
-    ServiceListResult,
-)
+from invenio_records_resources.services.base import ConditionalLink
 from invenio_records_resources.services.records.components import DataComponent
 from invenio_records_resources.services.records.params import (
     FilterParam,

--- a/tests/contrib/names/test_names_resource.py
+++ b/tests/contrib/names/test_names_resource.py
@@ -10,7 +10,6 @@
 """Test the name vocabulary resource."""
 
 import json
-from copy import deepcopy
 
 import pytest
 
@@ -193,8 +192,6 @@ def test_names_suggest_sort(client_with_credentials, example_multiple_names, h, 
     # With affiliation
     res = client_with_credentials.get(f"{prefix}?suggest=john%20wwe", headers=h)
     assert res.status_code == 200
-    assert (
-        res.json["hits"]["total"] == 3
-    )  # Will find 3 johns but WWE affiliation should be at the top
+    assert res.json["hits"]["total"] == 1
     assert res.json["hits"]["hits"][0]["name"] == "Cena, John"
     assert res.json["hits"]["hits"][0]["affiliations"][0]["name"] == "WWE"


### PR DESCRIPTION
- Closes https://github.com/inveniosoftware/invenio-vocabularies/issues/438
- Depends on https://github.com/inveniosoftware/invenio-records-resources/pull/602
- **names: add affiliation acronym in mappings and schema**
  * Dereferences the affiliation `acronym` when indexing names and serving
    REST API results. This is useful for disambiguating authors in search.
- **contrib: improve search accuracy for names, funders, affiliations**
  