### PR TITLE
subjects: improve search with CompositeSuggestQueryParser

### DIFF
--- a/invenio_vocabularies/contrib/subjects/config.py
+++ b/invenio_vocabularies/contrib/subjects/config.py
@@ -15,10 +15,12 @@ from invenio_i18n import get_locale
 from invenio_i18n import lazy_gettext as _
 from invenio_records_resources.services import SearchOptions
 from invenio_records_resources.services.records.components import DataComponent
+from invenio_records_resources.services.records.queryparser import (
+    CompositeSuggestQueryParser,
+)
 from werkzeug.local import LocalProxy
 
 from ...services.components import PIDComponent
-from ...services.querystr import FilteredSuggestQueryParser
 
 subject_schemes = LocalProxy(
     lambda: current_app.config["VOCABULARIES_SUBJECTS_SCHEMES"]
@@ -38,9 +40,8 @@ euroscivoc_file_url = LocalProxy(
 class SubjectsSearchOptions(SearchOptions):
     """Search options."""
 
-    suggest_parser_cls = FilteredSuggestQueryParser.factory(
-        filter_field="scheme",
-        fields=[  # suggest fields
+    suggest_parser_cls = CompositeSuggestQueryParser.factory(
+        fields=[
             "subject^100",
             localized_title,
             "synonyms^20",

--- a/invenio_vocabularies/services/querystr.py
+++ b/invenio_vocabularies/services/querystr.py
@@ -8,6 +8,7 @@
 
 """Querystring parsing."""
 
+import warnings
 from functools import partial
 
 from invenio_records_resources.services.records.params import SuggestQueryParser
@@ -20,6 +21,10 @@ class FilteredSuggestQueryParser(SuggestQueryParser):
     @classmethod
     def factory(cls, filter_field=None, **extra_params):
         """Create a prepared instance of the query parser."""
+        warnings.warn(
+            "FilteredSuggestQueryParser is deprecated, use SuggestQueryParser or CompositeSuggestQueryParser instead",
+            DeprecationWarning,
+        )
         return partial(cls, filter_field=filter_field, extra_params=extra_params)
 
     def __init__(self, identity=None, filter_field=None, extra_params=None):


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* Fixes #447 (see details in linked issue)
* The feature allowing to search by prefix (e.g. `EuroSciVoc:dementia`) used to have a corresponding UI automatically adding the prefixed filter.
Now that this is not in the UI anymore, since this search behavior is not documented, and since the search results of `FilteredSuggestQueryParser` are not good, we are proposing to:
    * Deprecate `FilteredSuggestQueryParser`
    * Use the recently introduced `CompositeSuggestQueryParser`, which narrows down results as more search terms are added

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
