### PR TITLE
names: ORCID Public Data Sync: detect default keys

### DIFF
--- a/invenio_vocabularies/config.py
+++ b/invenio_vocabularies/config.py
@@ -204,9 +204,9 @@ VOCABULARIES_AFFILIATIONS_EDMO_COUNTRY_MAPPING = {
 }
 """Affiliations EDMO Country name remapping dictionary."""
 
-VOCABULARIES_ORCID_ACCESS_KEY = "TODO"
+VOCABULARIES_ORCID_ACCESS_KEY = "CHANGEME"
 """ORCID access key to access the s3 bucket."""
-VOCABULARIES_ORCID_SECRET_KEY = "TODO"
+VOCABULARIES_ORCID_SECRET_KEY = "CHANGEME"
 """ORCID secret key to access the s3 bucket."""
 VOCABULARIES_ORCID_SUMMARIES_BUCKET = "v3.0-summaries"
 """ORCID summaries bucket name."""

--- a/invenio_vocabularies/contrib/names/s3client.py
+++ b/invenio_vocabularies/contrib/names/s3client.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2024 CERN.
+# Copyright (C) 2024-2025 CERN.
 #
 # Invenio-Vocabularies is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -38,7 +38,13 @@ class S3OrcidClient(S3Client):
 
     def __init__(self):
         """Constructor."""
+        access_key = current_app.config["VOCABULARIES_ORCID_ACCESS_KEY"]
+        secret_key = current_app.config["VOCABULARIES_ORCID_SECRET_KEY"]
+        if access_key == "CHANGEME" or secret_key == "CHANGEME":
+            raise Exception(
+                "VOCABULARIES_ORCID_ACCESS_KEY and VOCABULARIES_ORCID_SECRET_KEY are not configured."
+            )
         super().__init__(
-            access_key=current_app.config["VOCABULARIES_ORCID_ACCESS_KEY"],
-            secret_key=current_app.config["VOCABULARIES_ORCID_SECRET_KEY"],
+            access_key=access_key,
+            secret_key=secret_key,
         )


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* (Related) Fixes zenodo/zenodo-rdm#1176

Non-blocking small improvement to avoid calling the S3 client with the default keys.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
