### PR TITLE
fix: SADeprecationWarning

### DIFF
--- a/invenio_vocabularies/services/service.py
+++ b/invenio_vocabularies/services/service.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2024 CERN.
 # Copyright (C) 2021 Northwestern University.
 # Copyright (C) 2024 University of Münster.
+# Copyright (C) 2025 Graz University of Technology.
 #
 # Invenio-Vocabularies is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -42,7 +43,7 @@ class VocabularyTypeService(RecordService):
             filters.extend([VocabularyType.id.ilike(f"%{query_param}%")])
 
         vocabulary_types = (
-            VocabularyType.query.filter(sa.or_(*filters))
+            VocabularyType.query.filter(sa.or_(False, *filters))
             .order_by(
                 search_params["sort_direction"](
                     sa.text(",".join(search_params["sort"]))


### PR DESCRIPTION
* SADeprecationWarning: Invoking or_() without arguments is deprecated,
  and will be disallowed in a future release.   For an empty or_()
  construct, use 'or_(false(), *args)' or 'or_(False, *args)'.
    BannerModel.query.filter(or_(*filters))

* sqlalchemy/sqlalchemy#5054
