### PR TITLE
make it possible to search over id in affiliations, awards and funders

### DIFF
--- a/invenio_vocabularies/contrib/affiliations/config.py
+++ b/invenio_vocabularies/contrib/affiliations/config.py
@@ -45,6 +45,7 @@ class AffiliationsSearchOptions(SearchOptions):
             # Allow to search identifiers directly (e.g. ROR)
             "identifiers.identifier",
             "country_name",
+            "id",
         ],
     )
 

--- a/invenio_vocabularies/contrib/awards/config.py
+++ b/invenio_vocabularies/contrib/awards/config.py
@@ -41,6 +41,7 @@ class AwardsSearchOptions(SearchOptions):
             "acronym^100",
             "number^10",
             "identifiers.identifier^10",
+            "id",
         ],
     )
 

--- a/invenio_vocabularies/contrib/funders/config.py
+++ b/invenio_vocabularies/contrib/funders/config.py
@@ -44,6 +44,7 @@ class FundersSearchOptions(SearchOptions):
             # Allow to search identifiers directly (e.g. ROR)
             "identifiers.identifier",
             "country_name",
+            "id",
         ],
     )
 


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.

We have received  feedback from our users, that they would really appreciate, if it would be possible to search via id in some specialized vocabularies.

For example, ids of funders in Czech Republic are very well known and in many cases it would be easier for users to look for it based on id, than based on name or title or something like that. 

I don't think this PR bears any negative impact on the library and for us it would be useful to have it. Please if you can take a look and let us know if you would merge this. Thanks!

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
