### PR TITLE
react: Fix react dnd multiple HTML5backends bug

### DIFF
--- a/invenio_vocabularies/assets/semantic-ui/js/invenio_vocabularies/src/contrib/forms/Funding/FundingField.js
+++ b/invenio_vocabularies/assets/semantic-ui/js/invenio_vocabularies/src/contrib/forms/Funding/FundingField.js
@@ -1,6 +1,7 @@
 // This file is part of InvenioVocabularies
 // Copyright (C) 2021-2025 CERN.
 // Copyright (C) 2021 Northwestern University.
+// Copyright (C) 2025 CSC - IT Center for Science ltd.
 //
 // Invenio is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
@@ -8,7 +9,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { FieldArray, getIn } from "formik";
-import { HTML5Backend } from "react-dnd-html5-backend";
+import { manager } from "@js/invenio_rdm_records";
 import { DndProvider } from "react-dnd";
 import { Button, Form, Icon, List } from "semantic-ui-react";
 import { FieldLabel, FeedbackLabel } from "react-invenio-forms";
@@ -95,7 +96,7 @@ function FundingFieldForm(props) {
   }
 
   return (
-    <DndProvider backend={HTML5Backend}>
+    <DndProvider manager={manager}>
       <Form.Field required={required} className={className}>
         <FieldLabel htmlFor={fieldPath} icon={labelIcon} label={label} />
         <List>


### PR DESCRIPTION
React DnD should not use multiple HTML5 backends at the same time. Create one DnD manager, that is used InvenioRDM wide.

:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.

Modified React DnD functionality to have a single html5 backend compared to previous multiple html5 backends. React DnD does not support multiple html5 backends at once (check for example: https://github.com/react-dnd/react-dnd/issues/3119 )

Note! This PR is related to invenio-rdm-records PR: https://github.com/inveniosoftware/invenio-rdm-records/pull/2138

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
