### PR TITLE
service: fix read_all permission from search -> read

### DIFF
--- a/invenio_vocabularies/services/service.py
+++ b/invenio_vocabularies/services/service.py
@@ -146,7 +146,6 @@ class VocabulariesService(RecordService):
                 identity=identity,
                 record_cls=self.record_cls,
                 search_opts=self.config.search,
-                permission_action="search",
             ).query(search_query)
 
             results = dsl.response.Response(search, results)


### PR DESCRIPTION
I changed the approach; instead of updating the permission policy, which impacts other vocabulary permissions, this is the better way to use the correct permission.