### PR TITLE
fix(names): skip invalid ORCID entries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 ..
     Copyright (C) 2020-2025 CERN.
     Copyright (C) 2024-2026 Graz University of Technology.
+    Copyright (C) 2026 KTH Royal Institute of Technology.
 
     Invenio-Vocabularies is free software; you can redistribute it and/or
     modify it under the terms of the MIT License; see LICENSE file for more
@@ -8,6 +9,10 @@
 
 Changes
 =======
+
+Version v11.1.1 (released 2026-04-23)
+
+- fix(names): skip invalid ORCID entries
 
 Version v11.1.0 (released 2026-04-22)
 

--- a/invenio_vocabularies/__init__.py
+++ b/invenio_vocabularies/__init__.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2020-2026 CERN.
 # Copyright (C) 2024-2026 Graz University of Technology.
+# Copyright (C) 2026 KTH Royal Institute of Technology.
 #
 # Invenio-Vocabularies is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -11,6 +12,6 @@
 
 from .ext import InvenioVocabularies
 
-__version__ = "11.1.0"
+__version__ = "11.1.1"
 
 __all__ = ("__version__", "InvenioVocabularies")

--- a/invenio_vocabularies/contrib/names/datastreams.py
+++ b/invenio_vocabularies/contrib/names/datastreams.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2021-2026 CERN.
+# Copyright (C) 2026 KTH Royal Institute of Technology.
 #
 # Invenio-Vocabularies is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -276,10 +277,11 @@ class OrcidTransformer(BaseTransformer):
         given_names = name.get("given-names", None) if name else None
 
         if name is None or family_name is None:
-            current_app.logger.warning(
-                f"Missing name or family name for ORCID ID: {orcid_id}"
+            error = TransformerError(
+                f"Missing name or family name for ORCiD ID: {orcid_id}."
             )
-            stream_entry.filtered = True
+            stream_entry.errors.append(error)
+            current_app.logger.warning(error)
             return stream_entry
 
         full_name = " ".join(

--- a/tests/contrib/names/test_names_datastreams.py
+++ b/tests/contrib/names/test_names_datastreams.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2021-2024 CERN.
+# Copyright (C) 2026 KTH Royal Institute of Technology.
 #
 # Invenio-Vocabularies is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -359,6 +360,20 @@ def test_orcid_transformer_name_filtering(orcid_data, name, is_valid_name):
         val["person"]["name"]["family-name"] = name
         stream_entry = transformer.apply(StreamEntry(val))
         assert stream_entry.errors
+
+
+def test_orcid_transformer_missing_name_fields(app, orcid_data):
+    transformer = OrcidTransformer()
+    val = deepcopy(orcid_data["json"]["multi_employment"])
+
+    val["person"]["name"] = None
+    stream_entry = transformer.apply(StreamEntry(val))
+    assert stream_entry.errors
+
+    val = deepcopy(orcid_data["json"]["multi_employment"])
+    val["person"]["name"]["family-name"] = None
+    stream_entry = transformer.apply(StreamEntry(val))
+    assert stream_entry.errors
 
 
 @pytest.mark.parametrize("name", NAMES_TEST.keys())


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

closes https://github.com/inveniosoftware/invenio-app-rdm/issues/3351

This fixes the leak of raw ORCID records when `person.name` or `family-name` is missing.

Previously, those records were only marked filtered, but the datastream skips transformed entries based on errors, so they could still be written out unchanged.
Now we append a TransformerError and return early, which makes the pipeline correctly skip them.

A regression test was added to ensure missing-name ORCID records always produce errors and are not treated as valid transformed output.


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
