### PR TITLE
feat: added run_subtasks flag in datastream writer

### DIFF
--- a/invenio_vocabularies/cli.py
+++ b/invenio_vocabularies/cli.py
@@ -30,6 +30,7 @@ def _process_vocab(config, num_samples=None):
         transformers_config=config.get("transformers"),
         writers_config=config["writers"],
         batch_size=config.get("batch_size", 1000),
+        run_subtasks=config.get("run_subtasks", True),
         write_many=config.get("write_many", False),
     )
 

--- a/invenio_vocabularies/datastreams/datastreams.py
+++ b/invenio_vocabularies/datastreams/datastreams.py
@@ -60,6 +60,7 @@ class DataStream:
         transformers=None,
         batch_size=100,
         write_many=False,
+        run_subtasks=True,
         *args,
         **kwargs,
     ):
@@ -74,6 +75,7 @@ class DataStream:
         self._writers = writers
         self.batch_size = batch_size
         self.write_many = write_many
+        self.run_subtasks = run_subtasks
 
     def filter(self, stream_entry, *args, **kwargs):
         """Checks if an stream_entry should be filtered out (skipped)."""
@@ -206,7 +208,11 @@ class DataStream:
         current_app.logger.debug(f"Writing entry: {stream_entry.entry}")
         for writer in self._writers:
             try:
-                if writer.is_async and job_context.get() is not EMPTY_JOB_CTX:
+                if (
+                    self.run_subtasks
+                    and writer.is_async
+                    and job_context.get() is not EMPTY_JOB_CTX
+                ):
                     subtask_run_id = self._prepare_async_context()
                     writer.write(stream_entry, subtask_run_id=subtask_run_id)
                 else:
@@ -222,7 +228,11 @@ class DataStream:
         current_app.logger.debug(f"Batch writing entries: {len(stream_entries)}")
         for writer in self._writers:
             try:
-                if writer.is_async and job_context.get() is not EMPTY_JOB_CTX:
+                if (
+                    self.run_subtasks
+                    and writer.is_async
+                    and job_context.get() is not EMPTY_JOB_CTX
+                ):
                     subtask_run_id = self._prepare_async_context()
                     yield from writer.write_many(
                         stream_entries, subtask_run_id=subtask_run_id

--- a/invenio_vocabularies/fixtures.py
+++ b/invenio_vocabularies/fixtures.py
@@ -29,6 +29,7 @@ class VocabularyFixture:
             transformers_config=config.get("transformers"),
             writers_config=config["writers"],
             batch_size=config.get("batch_size", 1000),
+            run_subtasks=config.get("run_subtasks", True),
             write_many=config.get("write_many", False),
         )
 

--- a/invenio_vocabularies/services/tasks.py
+++ b/invenio_vocabularies/services/tasks.py
@@ -22,6 +22,7 @@ def process_datastream(config):
         transformers_config=config.get("transformers"),
         writers_config=config["writers"],
         batch_size=config.get("batch_size", 1000),
+        run_subtasks=config.get("run_subtasks", True),
         write_many=config.get("write_many", False),
     )
     entries_with_errors = 0


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Enables toggling async subtask creation based on job config.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
