### PR TITLE
awards: added short description in cordis datastream and resolve PIC to ROR

### DIFF
--- a/invenio_vocabularies/config.py
+++ b/invenio_vocabularies/config.py
@@ -149,6 +149,13 @@ VOCABULARIES_AWARDS_OPENAIRE_FUNDERS = {
 VOCABULARIES_AWARDS_EC_ROR_ID = "00k4n6c32"
 """ROR ID for EC funder."""
 
+VOCABULARIES_AWARDS_PIC_MAPPING_SOURCE = "10.5281/zenodo.21345462"
+"""Source of the PIC -> ROR mapping used by the CORDIS awards datastream.
+
+Zenodo concept DOI of the record holding ``pic_mapping.csv``, or a local
+CSV file path. Set to ``None`` to disable PIC resolution.
+"""
+
 VOCABULARIES_NAMES_SCHEMES = {
     "orcid": {"label": _("ORCID"), "validator": is_orcid, "datacite": "ORCID"},
     "isni": {"label": _("ISNI"), "validator": is_isni, "datacite": "ISNI"},

--- a/invenio_vocabularies/contrib/affiliations/jsonschemas/affiliations/affiliation-v1.0.0.json
+++ b/invenio_vocabularies/contrib/affiliations/jsonschemas/affiliations/affiliation-v1.0.0.json
@@ -22,6 +22,18 @@
       "type": "string",
       "description": "Represents a affiliation's location name (usually a city)."
     },
+    "website": {
+      "description": "Affiliation's website.",
+      "type": "string"
+    },
+    "domains": {
+      "description": "Domains of the affiliation.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
+    },
     "acronym": {
       "type": "string"
     },
@@ -34,8 +46,8 @@
       "uniqueItems": true
     },
     "status": {
-        "type": "string",
-        "description": "Status of the affiliation organization."
+      "type": "string",
+      "description": "Status of the affiliation organization."
     },
     "aliases": {
       "description": "Alternate names for the affiliation.",

--- a/invenio_vocabularies/contrib/affiliations/mappings/os-v1/affiliations/affiliation-v1.0.0.json
+++ b/invenio_vocabularies/contrib/affiliations/mappings/os-v1/affiliations/affiliation-v1.0.0.json
@@ -88,7 +88,7 @@
       },
       "tags": {
         "type": "keyword"
-      },    
+      },
       "country": {
         "type": "text"
       },
@@ -97,6 +97,12 @@
       },
       "location_name": {
         "type": "text"
+      },
+      "website": {
+        "type": "keyword"
+      },
+      "domains": {
+        "type": "keyword"
       },
       "status": {
         "type": "keyword"

--- a/invenio_vocabularies/contrib/affiliations/mappings/os-v1/affiliations/affiliation-v2.0.0.json
+++ b/invenio_vocabularies/contrib/affiliations/mappings/os-v1/affiliations/affiliation-v2.0.0.json
@@ -33,10 +33,7 @@
         "accent_normalizer": {
           "type": "custom",
           "char_filter": ["strip_special_chars"],
-          "filter": [
-            "lowercase",
-            "asciifolding"
-          ]
+          "filter": ["lowercase", "asciifolding"]
         }
       },
       "filter": {
@@ -156,6 +153,12 @@
       },
       "location_name": {
         "type": "text"
+      },
+      "website": {
+        "type": "keyword"
+      },
+      "domains": {
+        "type": "keyword"
       },
       "status": {
         "type": "keyword"

--- a/invenio_vocabularies/contrib/affiliations/mappings/os-v2/affiliations/affiliation-v1.0.0.json
+++ b/invenio_vocabularies/contrib/affiliations/mappings/os-v2/affiliations/affiliation-v1.0.0.json
@@ -98,6 +98,12 @@
       "location_name": {
         "type": "text"
       },
+      "website": {
+        "type": "keyword"
+      },
+      "domains": {
+        "type": "keyword"
+      },
       "status": {
         "type": "keyword"
       },

--- a/invenio_vocabularies/contrib/affiliations/mappings/os-v2/affiliations/affiliation-v2.0.0.json
+++ b/invenio_vocabularies/contrib/affiliations/mappings/os-v2/affiliations/affiliation-v2.0.0.json
@@ -33,10 +33,7 @@
         "accent_normalizer": {
           "type": "custom",
           "char_filter": ["strip_special_chars"],
-          "filter": [
-            "lowercase",
-            "asciifolding"
-          ]
+          "filter": ["lowercase", "asciifolding"]
         }
       },
       "filter": {
@@ -156,6 +153,12 @@
       },
       "location_name": {
         "type": "text"
+      },
+      "website": {
+        "type": "keyword"
+      },
+      "domains": {
+        "type": "keyword"
       },
       "status": {
         "type": "keyword"

--- a/invenio_vocabularies/contrib/affiliations/schema.py
+++ b/invenio_vocabularies/contrib/affiliations/schema.py
@@ -8,7 +8,7 @@ from functools import partial
 
 from invenio_i18n import lazy_gettext as _
 from marshmallow import fields, validate
-from marshmallow_utils.fields import IdentifierSet, SanitizedUnicode
+from marshmallow_utils.fields import URL, IdentifierSet, SanitizedUnicode
 from marshmallow_utils.schemas import IdentifierSchema
 
 from ...services.schema import (
@@ -38,6 +38,8 @@ class AffiliationSchema(BaseVocabularySchema, ModePIDFieldVocabularyMixin):
     country = SanitizedUnicode()
     country_name = SanitizedUnicode()
     location_name = SanitizedUnicode()
+    website = URL()
+    domains = fields.List(SanitizedUnicode())
     id = SanitizedUnicode(
         validate=validate.Length(min=1, error=_("PID cannot be blank."))
     )

--- a/invenio_vocabularies/contrib/awards/awards.py
+++ b/invenio_vocabularies/contrib/awards/awards.py
@@ -24,6 +24,7 @@ from invenio_records_resources.resources.records.headers import etag_headers
 
 from invenio_vocabularies.services.permissions import PermissionPolicy
 
+from ..affiliations.api import Affiliation
 from ..funders.api import Funder
 from ..subjects.api import Subject
 from .config import AwardsSearchOptions, service_components
@@ -42,6 +43,12 @@ award_relations = MultiRelationsField(
         keys=["subject", "scheme", "identifiers", "props"],
         pid_field=Subject.pid,
         cache_key="subjects",
+    ),
+    organizations=PIDListRelation(
+        "organizations",
+        keys=["name", "identifiers"],
+        pid_field=Affiliation.pid,
+        cache_key="affiliations",
     ),
 )
 

--- a/invenio_vocabularies/contrib/awards/datastreams.py
+++ b/invenio_vocabularies/contrib/awards/datastreams.py
@@ -175,11 +175,28 @@ class CORDISProjectTransformer(BaseTransformer):
             f"{current_app.config['VOCABULARIES_AWARDS_EC_ROR_ID']}::{record['id']}"
         )
 
+        article_data = (
+            record.get("relations", {}).get("associations", {}).get("article", {})
+        )
+
+        article_title = (
+            (
+                article_data[0]
+                if isinstance(article_data, list) and article_data
+                else article_data
+            ).get("title")
+            if article_data
+            else None
+        )
+
+        short_description = (article_title or record.get("teaser") or "")[:250]
+        if short_description:
+            award["short_description"] = {"en": short_description}
+
         categories = record.get("relations", {}).get("categories", {}).get("category")
         if categories:
             if isinstance(categories, dict):
                 categories = [categories]
-
             award["subjects"] = [
                 {"id": f"euroscivoc:{vocab_id}"}
                 for category in categories
@@ -265,7 +282,6 @@ class CORDISProjectTransformer(BaseTransformer):
                     )
                     if programme_related_legal_basis["uniqueprogrammepart"] == "true"
                 ][0]
-
             # Store the code of the programme.
             # For instance the code "HORIZON.1.2" which means "Marie Skłodowska-Curie Actions (MSCA)"
             # See https://cordis.europa.eu/programme/id/HORIZON.1.2

--- a/invenio_vocabularies/contrib/awards/datastreams.py
+++ b/invenio_vocabularies/contrib/awards/datastreams.py
@@ -286,6 +286,15 @@ class CORDISProjectTransformer(BaseTransformer):
         if "objective" in record:
             award["description"] = {"en": record["objective"]}
 
+        # Add the Grant DOI to the `identifiers` list (this is not provided by OpenAIRE).
+        if "grantdoi" in record.get("identifiers", {}):
+            award["identifiers"].append(
+                {
+                    "identifier": record["identifiers"]["grantdoi"],
+                    "scheme": "doi",
+                }
+            )
+
         # The `short_description` field.
         article_data = (
             record.get("relations", {}).get("associations", {}).get("article", {})

--- a/invenio_vocabularies/contrib/awards/datastreams.py
+++ b/invenio_vocabularies/contrib/awards/datastreams.py
@@ -186,8 +186,8 @@ class CORDISProjectTransformer(BaseTransformer):
         :param pic_mapping: Explicit ``{pic: ror}`` dict (used by tests). When ``None``,
             the mapping is lazy-loaded on first access from the merged
             :attr:`pic_mapping_params`. If no ``source`` ends up set (neither in the
-            merged params nor in ``VOCABULARIES_AWARDS_PIC_MAPPING_SOURCE``), the
-            transformer falls back to the legacy PIC-only ``organizations`` shape.
+            merged params nor in ``VOCABULARIES_AWARDS_PIC_MAPPING_SOURCE``), all
+            organizations are emitted as free-text names.
         :param pic_mapping_params: Per-instance overrides for
             :attr:`pic_mapping_params`; kwarg keys win over the class default.
         """

--- a/invenio_vocabularies/contrib/awards/datastreams.py
+++ b/invenio_vocabularies/contrib/awards/datastreams.py
@@ -320,9 +320,7 @@ class CORDISProjectTransformer(BaseTransformer):
                 if ror:
                     award["organizations"].append({"id": ror})
                 else:
-                    award["organizations"].append(
-                        {"organization": organization["legalname"]}
-                    )
+                    award["organizations"].append({"name": organization["legalname"]})
 
         programmes = (
             record.get("relations", {}).get("associations", {}).get("programme", {})

--- a/invenio_vocabularies/contrib/awards/datastreams.py
+++ b/invenio_vocabularies/contrib/awards/datastreams.py
@@ -170,11 +170,28 @@ class CORDISProjectTransformer(BaseTransformer):
             f"{current_app.config['VOCABULARIES_AWARDS_EC_ROR_ID']}::{record['id']}"
         )
 
+        article_data = (
+            record.get("relations", {}).get("associations", {}).get("article", {})
+        )
+
+        article_title = (
+            (
+                article_data[0]
+                if isinstance(article_data, list) and article_data
+                else article_data
+            ).get("title")
+            if article_data
+            else None
+        )
+
+        short_description = (article_title or record.get("teaser") or "")[:250]
+        if short_description:
+            award["short_description"] = {"en": short_description}
+
         categories = record.get("relations", {}).get("categories", {}).get("category")
         if categories:
             if isinstance(categories, dict):
                 categories = [categories]
-
             award["subjects"] = [
                 {"id": f"euroscivoc:{vocab_id}"}
                 for category in categories
@@ -260,7 +277,6 @@ class CORDISProjectTransformer(BaseTransformer):
                     )
                     if programme_related_legal_basis["uniqueprogrammepart"] == "true"
                 ][0]
-
             # Store the code of the programme.
             # For instance the code "HORIZON.1.2" which means "Marie Skłodowska-Curie Actions (MSCA)"
             # See https://cordis.europa.eu/programme/id/HORIZON.1.2

--- a/invenio_vocabularies/contrib/awards/datastreams.py
+++ b/invenio_vocabularies/contrib/awards/datastreams.py
@@ -3,16 +3,22 @@
 
 """Awards datastreams, transformers, writers and readers."""
 
+import csv
 import io
+import os
 
 import requests
 from flask import current_app
+from idutils import is_doi
 from invenio_access.permissions import system_identity
 from invenio_i18n import lazy_gettext as _
 
-from invenio_vocabularies.datastreams.errors import ReaderError
+from invenio_vocabularies.contrib.common.utils import (
+    DOIFileFetchError,
+    fetch_doi_file,
+)
 
-from ...datastreams.errors import TransformerError
+from ...datastreams.errors import ReaderError, TransformerError
 from ...datastreams.readers import BaseReader
 from ...datastreams.transformers import BaseTransformer
 from ...datastreams.writers import ServiceWriter
@@ -160,6 +166,95 @@ class CORDISProjectHTTPReader(BaseReader):
 class CORDISProjectTransformer(BaseTransformer):
     """Transforms a CORDIS project record into an award record."""
 
+    pic_mapping_params = {
+        "source": None,
+        "filename": "pic_mapping.csv",
+        "accepted_confidence": frozenset({"high", "medium", "manual"}),
+    }
+    """Defaults for the PIC -> ROR mapping loader.
+
+    - ``source``: Zenodo concept DOI or local CSV path. When ``None``, the
+      ``VOCABULARIES_AWARDS_PIC_MAPPING_SOURCE`` config is used.
+    - ``filename``: filename of the mapping CSV inside the Zenodo record.
+    - ``accepted_confidence``: rows whose ``confidence`` column is not in this set
+      are dropped.
+    """
+
+    def __init__(self, *args, pic_mapping=None, pic_mapping_params=None, **kwargs):
+        """Constructor.
+
+        :param pic_mapping: Explicit ``{pic: ror}`` dict (used by tests). When ``None``,
+            the mapping is lazy-loaded on first access from the merged
+            :attr:`pic_mapping_params`. If no ``source`` ends up set (neither in the
+            merged params nor in ``VOCABULARIES_AWARDS_PIC_MAPPING_SOURCE``), the
+            transformer falls back to the legacy PIC-only ``organizations`` shape.
+        :param pic_mapping_params: Per-instance overrides for
+            :attr:`pic_mapping_params`; kwarg keys win over the class default.
+        """
+        super().__init__(*args, **kwargs)
+        self._pic_mapping = pic_mapping
+        self._pic_mapping_params = {
+            **self.pic_mapping_params,
+            **(pic_mapping_params or {}),
+        }
+
+    @property
+    def pic_mapping(self):
+        """PIC -> ROR mapping. Loaded lazily on first access."""
+        if self._pic_mapping is None:
+            params = self._pic_mapping_params
+            source = params["source"] or current_app.config.get(
+                "VOCABULARIES_AWARDS_PIC_MAPPING_SOURCE"
+            )
+            self._pic_mapping = (
+                self._load_pic_mapping(
+                    source,
+                    filename=params["filename"],
+                    accepted_confidence=params["accepted_confidence"],
+                )
+                if source
+                else {}
+            )
+        return self._pic_mapping
+
+    @staticmethod
+    def _load_pic_mapping(source, *, filename, accepted_confidence):
+        """Load the PIC -> ROR mapping into a ``{pic: ror_id}`` dict.
+
+        The producer side merges human overrides into the published
+        CSV before publication, so the consumer reads a single file.
+
+        :param source: Concept DOI of the Zenodo record holding the mapping, or a
+            local file path to the CSV.
+        :param filename: Filename of the mapping CSV inside the Zenodo record (used to
+            pick the right item from the linkset).
+        :param accepted_confidence: Rows whose ``confidence`` column is not in this set
+            are dropped.
+        """
+        if is_doi(source):
+            try:
+                csv_bytes = fetch_doi_file(
+                    source,
+                    lambda item: item.get("href", "").endswith("/" + filename),
+                )
+            except DOIFileFetchError as e:
+                raise TransformerError(str(e)) from e
+        else:
+            if not os.path.isfile(source):
+                raise TransformerError(f"PIC mapping file not found at {source}")
+            with open(source, "rb") as fp:
+                csv_bytes = fp.read()
+
+        mapping = {}
+        for row in csv.DictReader(io.StringIO(csv_bytes.decode("utf-8"))):
+            if (row.get("confidence") or "").strip() not in accepted_confidence:
+                continue
+            pic = (row.get("pic") or "").strip()
+            ror = (row.get("ror_id") or "").strip()
+            if pic and ror:
+                mapping[pic] = ror
+        return mapping
+
     def apply(self, stream_entry, **kwargs):
         """Applies the transformation to the stream entry."""
         record = stream_entry.entry
@@ -208,6 +303,7 @@ class CORDISProjectTransformer(BaseTransformer):
             organizations = (
                 organizations if isinstance(organizations, list) else [organizations]
             )
+            pic_mapping = self.pic_mapping
             award["organizations"] = []
             for organization in organizations:
                 # Some organizations in FP7 projects do not have a "legalname" key,
@@ -216,22 +312,17 @@ class CORDISProjectTransformer(BaseTransformer):
                 if "legalname" not in organization:
                     continue
 
-                organization_data = {
-                    "organization": organization["legalname"],
-                }
-
                 # Some organizations in FP7 projects do not have an "id" key (the PIC identifier),
                 # for instance "AIlGreenVehicles" in "MOTORBRAIN" https://cordis.europa.eu/project/id/270693.
-                # In this case, still store the name but skip the identifier part.
-                if "id" in organization:
-                    organization_data.update(
-                        {
-                            "scheme": "pic",
-                            "id": organization["id"],
-                        }
-                    )
+                pic = organization.get("id")
+                ror = pic_mapping.get(pic) if pic else None
 
-                award["organizations"].append(organization_data)
+                if ror:
+                    award["organizations"].append({"id": ror})
+                else:
+                    award["organizations"].append(
+                        {"organization": organization["legalname"]}
+                    )
 
         programmes = (
             record.get("relations", {}).get("associations", {}).get("programme", {})

--- a/invenio_vocabularies/contrib/awards/datastreams.py
+++ b/invenio_vocabularies/contrib/awards/datastreams.py
@@ -260,11 +260,33 @@ class CORDISProjectTransformer(BaseTransformer):
         record = stream_entry.entry
         award = {}
 
-        # Here `id` is the project ID, which will be used to attach the update to the existing project.
-        award["id"] = (
-            f"{current_app.config['VOCABULARIES_AWARDS_EC_ROR_ID']}::{record['id']}"
-        )
+        funder_id = current_app.config["VOCABULARIES_AWARDS_EC_ROR_ID"]
+        grant_agreement_id = record["id"]
 
+        # The `id` field is used to uniquely identify an award and is mandatory.
+        award["id"] = f"{funder_id}::{grant_agreement_id}"
+
+        # Some fields also provided by OpenAIRE, but that we get here from CORDIS too.
+        award["funder"] = {"id": funder_id}
+        award["number"] = grant_agreement_id
+        award["identifiers"] = [
+            {
+                "identifier": f"https://cordis.europa.eu/projects/{grant_agreement_id}",
+                "scheme": "url",
+            }
+        ]
+        if "title" in record:
+            award["title"] = {"en": record["title"]}
+        if "acronym" in record:
+            award["acronym"] = record["acronym"]
+        if "startdate" in record:
+            award["start_date"] = record["startdate"]
+        if "enddate" in record:
+            award["end_date"] = record["enddate"]
+        if "objective" in record:
+            award["description"] = {"en": record["objective"]}
+
+        # The `short_description` field.
         article_data = (
             record.get("relations", {}).get("associations", {}).get("article", {})
         )
@@ -283,6 +305,7 @@ class CORDISProjectTransformer(BaseTransformer):
         if short_description:
             award["short_description"] = {"en": short_description}
 
+        # The `subjects` field.
         categories = record.get("relations", {}).get("categories", {}).get("category")
         if categories:
             if isinstance(categories, dict):
@@ -294,6 +317,7 @@ class CORDISProjectTransformer(BaseTransformer):
                 and (vocab_id := category["code"].split("/")[-1]).isdigit()
             ]
 
+        # The `organizations` field.
         organizations = (
             record.get("relations", {}).get("associations", {}).get("organization")
         )
@@ -322,6 +346,7 @@ class CORDISProjectTransformer(BaseTransformer):
                 else:
                     award["organizations"].append({"name": organization["legalname"]})
 
+        # The `program` field.
         programmes = (
             record.get("relations", {}).get("associations", {}).get("programme", {})
         )

--- a/invenio_vocabularies/contrib/awards/jsonschemas/awards/award-v1.0.0.json
+++ b/invenio_vocabularies/contrib/awards/jsonschemas/awards/award-v1.0.0.json
@@ -43,6 +43,9 @@
     "program": {
       "type": "string"
     },
+    "short_description": {
+      "$ref": "local://vocabularies/definitions-v1.0.0.json#/description"
+    },
     "start_date": {
       "type": "string"
     },

--- a/invenio_vocabularies/contrib/awards/jsonschemas/awards/award-v1.0.0.json
+++ b/invenio_vocabularies/contrib/awards/jsonschemas/awards/award-v1.0.0.json
@@ -83,8 +83,12 @@
             "description": "Identifier of the organization for the given scheme.",
             "$ref": "local://definitions-v1.0.0.json#/identifier"
           },
-          "organization": {
+          "name": {
             "description": "Human readable label.",
+            "type": "string"
+          },
+          "organization": {
+            "description": "Human readable label (deprecated, use name).",
             "type": "string"
           }
         }

--- a/invenio_vocabularies/contrib/awards/mappings/os-v1/awards/award-v1.0.0.json
+++ b/invenio_vocabularies/contrib/awards/mappings/os-v1/awards/award-v1.0.0.json
@@ -12,7 +12,7 @@
       },
       {
         "i18n_description": {
-          "path_match": "description.*",
+          "path_match": "*description.*",
           "match_mapping_type": "string",
           "mapping": {
             "type": "text"
@@ -84,6 +84,10 @@
       },
       "program": {
         "type": "keyword"
+      },
+      "short_description": {
+        "type": "object",
+        "dynamic": "true"
       },
       "subjects": {
         "properties": {

--- a/invenio_vocabularies/contrib/awards/mappings/os-v1/awards/award-v1.0.0.json
+++ b/invenio_vocabularies/contrib/awards/mappings/os-v1/awards/award-v1.0.0.json
@@ -121,6 +121,9 @@
       },
       "organizations": {
         "properties": {
+          "@v": {
+            "type": "keyword"
+          },
           "scheme": {
             "type": "keyword"
           },
@@ -129,6 +132,19 @@
           },
           "organization": {
             "type": "keyword"
+          },
+          "name": {
+            "type": "text"
+          },
+          "identifiers": {
+            "properties": {
+              "identifier": {
+                "type": "keyword"
+              },
+              "scheme": {
+                "type": "keyword"
+              }
+            }
           }
         }
       },

--- a/invenio_vocabularies/contrib/awards/mappings/os-v2/awards/award-v1.0.0.json
+++ b/invenio_vocabularies/contrib/awards/mappings/os-v2/awards/award-v1.0.0.json
@@ -12,7 +12,7 @@
       },
       {
         "i18n_description": {
-          "path_match": "description.*",
+          "path_match": "*description.*",
           "match_mapping_type": "string",
           "mapping": {
             "type": "text"
@@ -84,6 +84,10 @@
       },
       "program": {
         "type": "keyword"
+      },
+      "short_description": {
+        "type": "object",
+        "dynamic": "true"
       },
       "subjects": {
         "properties": {

--- a/invenio_vocabularies/contrib/awards/mappings/os-v2/awards/award-v1.0.0.json
+++ b/invenio_vocabularies/contrib/awards/mappings/os-v2/awards/award-v1.0.0.json
@@ -121,6 +121,9 @@
       },
       "organizations": {
         "properties": {
+          "@v": {
+            "type": "keyword"
+          },
           "scheme": {
             "type": "keyword"
           },
@@ -129,6 +132,19 @@
           },
           "organization": {
             "type": "keyword"
+          },
+          "name": {
+            "type": "text"
+          },
+          "identifiers": {
+            "properties": {
+              "identifier": {
+                "type": "keyword"
+              },
+              "scheme": {
+                "type": "keyword"
+              }
+            }
           }
         }
       },

--- a/invenio_vocabularies/contrib/awards/mappings/v7/awards/award-v1.0.0.json
+++ b/invenio_vocabularies/contrib/awards/mappings/v7/awards/award-v1.0.0.json
@@ -12,7 +12,7 @@
       },
       {
         "i18n_description": {
-          "path_match": "description.*",
+          "path_match": "*description.*",
           "match_mapping_type": "string",
           "mapping": {
             "type": "text"
@@ -84,6 +84,10 @@
       },
       "program": {
         "type": "keyword"
+      },
+      "short_description": {
+        "type": "object",
+        "dynamic": "true"
       },
       "subjects": {
         "properties": {

--- a/invenio_vocabularies/contrib/awards/mappings/v7/awards/award-v1.0.0.json
+++ b/invenio_vocabularies/contrib/awards/mappings/v7/awards/award-v1.0.0.json
@@ -121,6 +121,9 @@
       },
       "organizations": {
         "properties": {
+          "@v": {
+            "type": "keyword"
+          },
           "scheme": {
             "type": "keyword"
           },
@@ -129,6 +132,19 @@
           },
           "organization": {
             "type": "keyword"
+          },
+          "name": {
+            "type": "text"
+          },
+          "identifiers": {
+            "properties": {
+              "identifier": {
+                "type": "keyword"
+              },
+              "scheme": {
+                "type": "keyword"
+              }
+            }
           }
         }
       },

--- a/invenio_vocabularies/contrib/awards/schema.py
+++ b/invenio_vocabularies/contrib/awards/schema.py
@@ -57,6 +57,8 @@ class AwardSchema(BaseVocabularySchema, ModePIDFieldVocabularyMixin):
 
     program = SanitizedUnicode()
 
+    short_description = i18n_strings
+
     subjects = fields.List(fields.Nested(SubjectRelationSchema))
 
     organizations = fields.List(fields.Nested(AwardOrganizationRelationSchema))

--- a/invenio_vocabularies/contrib/awards/schema.py
+++ b/invenio_vocabularies/contrib/awards/schema.py
@@ -6,7 +6,14 @@
 from functools import partial
 
 from invenio_i18n import lazy_gettext as _
-from marshmallow import Schema, ValidationError, fields, validate, validates_schema
+from marshmallow import (
+    EXCLUDE,
+    Schema,
+    ValidationError,
+    fields,
+    validate,
+    validates_schema,
+)
 from marshmallow_utils.fields import IdentifierSet, ISODateString, SanitizedUnicode
 from marshmallow_utils.schemas import IdentifierSchema
 
@@ -16,18 +23,42 @@ from ...services.schema import (
     ModePIDFieldVocabularyMixin,
     i18n_strings,
 )
+from ..affiliations.config import affiliation_schemes
 from ..funders.schema import FunderRelationSchema
 from ..subjects.schema import SubjectRelationSchema
 from .config import award_schemes
 
 
 class AwardOrganizationRelationSchema(ContribVocabularyRelationSchema):
-    """Schema to define an organization relation in an award."""
+    """Schema to define an organization relation in an award.
+
+    ``id`` is dereferenced against the ``affiliations`` vocabulary,
+    so passing just ``{"id": "<ror>"}`` populates ``name`` and
+    ``identifiers`` on read.
+    """
+
+    # `ServiceWriter._do_update` merges the dumped entry back in, so dump-only
+    # `name`/`identifiers` would fail load validation on re-update without this.
+    class Meta:
+        """Metadata class."""
+
+        unknown = EXCLUDE
 
     ftf_name = "organization"
     parent_field_name = "organizations"
     organization = SanitizedUnicode()
     scheme = SanitizedUnicode()
+    name = SanitizedUnicode(dump_only=True)
+    identifiers = IdentifierSet(
+        fields.Nested(
+            partial(
+                IdentifierSchema,
+                allowed_schemes=affiliation_schemes,
+                identifier_required=False,
+            )
+        ),
+        dump_only=True,
+    )
 
 
 class AwardSchema(BaseVocabularySchema, ModePIDFieldVocabularyMixin):

--- a/invenio_vocabularies/contrib/awards/schema.py
+++ b/invenio_vocabularies/contrib/awards/schema.py
@@ -37,18 +37,19 @@ class AwardOrganizationRelationSchema(ContribVocabularyRelationSchema):
     ``identifiers`` on read.
     """
 
-    # `ServiceWriter._do_update` merges the dumped entry back in, so dump-only
-    # `name`/`identifiers` would fail load validation on re-update without this.
+    # `ServiceWriter._do_update` merges the dumped entry back in, so the
+    # dump-only `identifiers` would fail load validation on re-update without this.
     class Meta:
         """Metadata class."""
 
         unknown = EXCLUDE
 
-    ftf_name = "organization"
+    ftf_name = "name"
     parent_field_name = "organizations"
+    name = SanitizedUnicode()
+    # Deprecated in favor of `name`; kept so existing data still validates.
     organization = SanitizedUnicode()
     scheme = SanitizedUnicode()
-    name = SanitizedUnicode(dump_only=True)
     identifiers = IdentifierSet(
         fields.Nested(
             partial(
@@ -59,6 +60,13 @@ class AwardOrganizationRelationSchema(ContribVocabularyRelationSchema):
         ),
         dump_only=True,
     )
+
+    @validates_schema
+    def validate_relation_schema(self, data, **kwargs):
+        """Accept the legacy free-text `organization` key as alternative to `name`."""
+        if data.get("organization"):
+            return
+        super().validate_relation_schema(data, **kwargs)
 
 
 class AwardSchema(BaseVocabularySchema, ModePIDFieldVocabularyMixin):

--- a/invenio_vocabularies/contrib/awards/schema.py
+++ b/invenio_vocabularies/contrib/awards/schema.py
@@ -52,6 +52,8 @@ class AwardSchema(BaseVocabularySchema, ModePIDFieldVocabularyMixin):
 
     program = SanitizedUnicode()
 
+    short_description = i18n_strings
+
     subjects = fields.List(fields.Nested(SubjectRelationSchema))
 
     organizations = fields.List(fields.Nested(AwardOrganizationRelationSchema))

--- a/invenio_vocabularies/contrib/awards/serializer.py
+++ b/invenio_vocabularies/contrib/awards/serializer.py
@@ -39,6 +39,7 @@ class AwardL10NItemSchema(Schema):
     number = fields.String(dump_only=True)
     acronym = fields.String(dump_only=True)
     program = fields.String(dump_only=True)
+    short_description = L10NString(data_key="short_description_l10n")
     funder = fields.Nested(FunderRelationSchema, dump_only=True)
     subjects = fields.List(fields.Nested(SubjectRelationSchema), dump_only=True)
     identifiers = fields.List(fields.Nested(IdentifierSchema), dump_only=True)

--- a/invenio_vocabularies/contrib/awards/serializer.py
+++ b/invenio_vocabularies/contrib/awards/serializer.py
@@ -34,6 +34,7 @@ class AwardL10NItemSchema(Schema):
     number = fields.String(dump_only=True)
     acronym = fields.String(dump_only=True)
     program = fields.String(dump_only=True)
+    short_description = L10NString(data_key="short_description_l10n")
     funder = fields.Nested(FunderRelationSchema, dump_only=True)
     subjects = fields.List(fields.Nested(SubjectRelationSchema), dump_only=True)
     identifiers = fields.List(fields.Nested(IdentifierSchema), dump_only=True)

--- a/invenio_vocabularies/contrib/common/openaire/datastreams.py
+++ b/invenio_vocabularies/contrib/common/openaire/datastreams.py
@@ -5,9 +5,10 @@
 
 import io
 
-import requests
-
-from invenio_vocabularies.contrib.common.utils import invenio_user_agent
+from invenio_vocabularies.contrib.common.utils import (
+    DOIFileFetchError,
+    fetch_doi_file,
+)
 from invenio_vocabularies.datastreams.errors import ReaderError
 from invenio_vocabularies.datastreams.readers import BaseReader
 
@@ -33,45 +34,23 @@ class OpenAIREHTTPReader(BaseReader):
             )
 
         if self._origin == "full":
-            # OpenAIRE Graph Dataset
-            api_url = "https://zenodo.org/api/records/3516917"
+            # OpenAIRE Graph Dataset (concept DOI)
+            doi = "10.5281/zenodo.3516917"
         elif self._origin == "diff":
-            # OpenAIRE Graph dataset: new collected projects
-            api_url = "https://zenodo.org/api/records/6419021"
+            # OpenAIRE Graph Dataset: new collected projects (concept DOI)
+            doi = "10.5281/zenodo.6419021"
         else:
             raise ReaderError("The --origin option should be either 'full' or 'diff'")
 
-        # Call the signposting `linkset+json` endpoint for the Concept DOI (i.e. latest version) of the OpenAIRE Graph Dataset.
-        # See: https://github.com/inveniosoftware/rfcs/blob/master/rfcs/rdm-0071-signposting.md#provide-an-applicationlinksetjson-endpoint
-        headers = {
-            "Accept": "application/linkset+json",
-            "User-Agent": invenio_user_agent(),
-        }
-        api_resp = requests.get(api_url, headers=headers)
-        api_resp.raise_for_status()
-
-        # Extract the Landing page Link Set Object located as the first (index 0) item.
-        landing_page_linkset = api_resp.json()["linkset"][0]
-
-        # Extract the URL of the only tar file matching `tar_hrefs` linked to the record.
-        landing_page_matching_tar_items = [
-            item
-            for item in landing_page_linkset["item"]
-            if item["type"] == "application/x-tar"
-            and item["href"].endswith(tuple(self.tar_hrefs))
-        ]
-        if len(landing_page_matching_tar_items) != 1:
-            raise ReaderError(
-                f"Expected 1 tar item matching {self.tar_hrefs} but got {len(landing_page_matching_tar_items)}"
+        try:
+            file_bytes = fetch_doi_file(
+                doi,
+                lambda item: item.get("type") == "application/x-tar"
+                and item.get("href", "").endswith(tuple(self.tar_hrefs)),
             )
-        file_url = landing_page_matching_tar_items[0]["href"]
-
-        # Download the matching tar file and fully load the response bytes content in memory.
-        # The bytes content are then wrapped by a BytesIO to be file-like object (as required by `tarfile.open`).
-        # Using directly `file_resp.raw` is not possible since `tarfile.open` requires the file-like object to be seekable.
-        file_resp = requests.get(file_url, headers={"User-Agent": invenio_user_agent()})
-        file_resp.raise_for_status()
-        yield io.BytesIO(file_resp.content)
+        except DOIFileFetchError as e:
+            raise ReaderError(str(e)) from e
+        yield io.BytesIO(file_bytes)
 
 
 VOCABULARIES_DATASTREAM_READERS = {

--- a/invenio_vocabularies/contrib/common/ror/datastreams.py
+++ b/invenio_vocabularies/contrib/common/ror/datastreams.py
@@ -7,14 +7,18 @@
 import io
 from datetime import datetime
 
-import requests
 from flask import current_app
 from idutils import normalize_ror
 
-from invenio_vocabularies.contrib.common.utils import invenio_user_agent
+from invenio_vocabularies.contrib.common.utils import (
+    DOIFileFetchError,
+    fetch_doi_file,
+)
 from invenio_vocabularies.datastreams.errors import ReaderError, TransformerError
 from invenio_vocabularies.datastreams.readers import BaseReader
 from invenio_vocabularies.datastreams.transformers import BaseTransformer
+
+ROR_DATA_DUMP_DOI = "10.5281/zenodo.6347574"
 
 
 class RORHTTPReader(BaseReader):
@@ -35,35 +39,6 @@ class RORHTTPReader(BaseReader):
             "and therefore does not iterate through items"
         )
 
-    def _get_last_dump_date(self, linksets):
-        """Get the last dump date."""
-        for linkset in linksets:
-            metadata_formats = linkset.get("describedby", [])
-            for format_link in metadata_formats:
-                if format_link.get("type") == "application/ld+json":
-                    json_ld_reponse = requests.get(
-                        format_link["href"],
-                        headers={
-                            "Accept": format_link["type"],
-                            "User-Agent": invenio_user_agent(),
-                        },
-                    )
-                    json_ld_reponse.raise_for_status()
-                    json_ld_data = json_ld_reponse.json()
-
-                    last_dump_date = json_ld_data.get(
-                        "dateCreated"
-                    ) or json_ld_data.get("datePublished")
-                    last_dump_date = datetime.fromisoformat(
-                        last_dump_date.replace("Z", "+00:00")
-                    )
-                    return last_dump_date
-        else:
-            raise ReaderError(
-                "Couldn't find JSON-LD in publisher's linkset "
-                "to determine last dump date."
-            )
-
     def read(self, item=None, *args, **kwargs):
         """Reads the latest ROR data dump.
 
@@ -75,59 +50,23 @@ class RORHTTPReader(BaseReader):
                 "RORHTTPReader does not support being chained after another reader"
             )
 
-        # Follow the DOI to get the link of the linkset
-        dataset_doi_link = "https://doi.org/10.5281/zenodo.6347574"
-        landing_page = requests.get(
-            dataset_doi_link,
-            headers={"User-Agent": invenio_user_agent()},
-            allow_redirects=True,
+        since = (
+            datetime.fromisoformat(self._since)
+            if self._since and self._since != "None"
+            else None
         )
-        landing_page.raise_for_status()
-
-        # Call the signposting `linkset+json` endpoint for
-        # the Concept DOI (i.e. latest version) of the ROR data dump.
-        # See: https://github.com/inveniosoftware/rfcs/blob/master/rfcs/rdm-0071-signposting.md#provide-an-applicationlinksetjson-endpoint
-        if "linkset" not in landing_page.links:
-            raise ReaderError("Linkset not found in the ROR dataset record.")
-        linkset_response = requests.get(
-            landing_page.links["linkset"]["url"],
-            headers={
-                "Accept": "application/linkset+json",
-                "User-Agent": invenio_user_agent(),
-            },
-        )
-        linkset_response.raise_for_status()
-        linksets = linkset_response.json()["linkset"]
-
-        if self._since and self._since != "None":
-            last_dump_date = self._get_last_dump_date(linksets)
-            since = datetime.fromisoformat(self._since)
-
-            if last_dump_date < since:
-                current_app.logger.info(
-                    f"Skipping ROR data dump (last dump: {last_dump_date}, since: {self._since})"
-                )
-                return
-
-        for linkset in linksets:
-            items = linkset.get("item", [])
-            zip_files = [item for item in items if item["type"] == "application/zip"]
-            if len(zip_files) == 1:
-                file_url = zip_files[0]["href"]
-                break
-            if len(zip_files) > 1:
-                raise ReaderError(f"Expected 1 ZIP item but got {len(zip_files)}")
-
-        current_app.logger.info(f"Reading ROR data dump (URL: {file_url})")
-
-        # Download the ZIP file and fully load the response bytes content in memory.
-        # The bytes content are then wrapped by a BytesIO to be
-        # file-like object (as required by `zipfile.ZipFile`).
-        # Using directly `file_resp.raw` is not possible since
-        # `zipfile.ZipFile` requires the file-like object to be seekable.
-        file_resp = requests.get(file_url, headers={"User-Agent": invenio_user_agent()})
-        file_resp.raise_for_status()
-        yield io.BytesIO(file_resp.content)
+        try:
+            content = fetch_doi_file(
+                ROR_DATA_DUMP_DOI,
+                lambda i: i.get("type") == "application/zip",
+                since=since,
+            )
+        except DOIFileFetchError as e:
+            raise ReaderError(str(e)) from e
+        if content is None:
+            current_app.logger.info(f"Skipping ROR data dump (since: {self._since})")
+            return
+        yield io.BytesIO(content)
 
 
 VOCABULARIES_DATASTREAM_READERS = {

--- a/invenio_vocabularies/contrib/common/ror/datastreams.py
+++ b/invenio_vocabularies/contrib/common/ror/datastreams.py
@@ -91,6 +91,17 @@ class RORTransformer(BaseTransformer):
         ror = {}
         ror["title"] = {}
 
+        domains = record.get("domains", "")
+        if domains:
+            ror["domains"] = domains
+
+        links = record.get("links", [])
+        website = next(
+            (link.get("value") for link in links if link.get("type") == "website"), None
+        )
+        if website:
+            ror["website"] = website
+
         ror["id"] = normalize_ror(record.get("id"))
         if not ror["id"]:
             raise TransformerError(_("Id not found in ROR entry."))

--- a/invenio_vocabularies/contrib/common/utils.py
+++ b/invenio_vocabularies/contrib/common/utils.py
@@ -3,7 +3,14 @@
 
 """Utility functions for Invenio-Vocabularies HTTP operations."""
 
+from datetime import datetime
+
+import requests
 from flask import current_app, has_app_context
+
+
+class DOIFileFetchError(Exception):
+    """Raised when a file cannot be fetched from a DOI via signposting."""
 
 
 def invenio_user_agent(default="Invenio"):
@@ -13,3 +20,81 @@ def invenio_user_agent(default="Invenio"):
         ui_url = current_app.config.get("SITE_UI_URL", None)
         return f"{hostname} (+{ui_url})" if ui_url else hostname
     return default
+
+
+def fetch_doi_file(doi, select_func, since=None):
+    """Fetch one file linked from a DOI via FAIR signposting.
+
+    Resolves the linksets advertised at ``doi`` (signposting profile,
+    RFC 9264 / inveniosoftware RDM-0071), picks the single item whose
+    metadata matches ``select_func``, and returns the bytes at its
+    ``href``. When ``since`` is given, the record's publication date
+    is read from the JSON-LD ``describedby`` entry first; if the
+    record was not republished after ``since``, ``None`` is returned
+    without fetching the file.
+
+    See https://github.com/inveniosoftware/rfcs/blob/master/rfcs/rdm-0071-signposting.md
+
+    :param doi: DOI (e.g. ``10.5281/zenodo.6347574``).
+    :param select_func: Callable invoked with each linkset ``item`` dict; the single
+        item for which it returns truthy is fetched.
+    :param since: Optional ``datetime``. The file is fetched only when the record was
+        republished at or after this point.
+    """
+    if not doi.startswith(("http://", "https://")):
+        doi = f"https://doi.org/{doi}"
+
+    with requests.Session() as session:
+        session.headers["User-Agent"] = invenio_user_agent()
+
+        # Resolve the DOI to the linkset endpoint via the rel="linkset" Link header.
+        resp = session.get(doi, allow_redirects=True)
+        resp.raise_for_status()
+        if "linkset" not in resp.links:
+            raise DOIFileFetchError(f"Linkset not found at {doi}")
+        linkset_resp = session.get(
+            resp.links["linkset"]["url"],
+            headers={"Accept": "application/linkset+json"},
+        )
+        linkset_resp.raise_for_status()
+        linksets = linkset_resp.json()["linkset"]
+
+        # If `since` is set, skip when the record's publication date is older.
+        if since is not None:
+            ld_link = next(
+                (
+                    fmt
+                    for linkset in linksets
+                    for fmt in linkset.get("describedby", [])
+                    if fmt.get("type") == "application/ld+json"
+                ),
+                None,
+            )
+            if ld_link is None:
+                raise DOIFileFetchError(f"No JSON-LD describedby entry found for {doi}")
+            ld_resp = session.get(ld_link["href"], headers={"Accept": ld_link["type"]})
+            ld_resp.raise_for_status()
+            ld_data = ld_resp.json()
+            date_str = ld_data.get("dateCreated") or ld_data.get("datePublished")
+            if not date_str:
+                raise DOIFileFetchError(
+                    f"JSON-LD at {ld_link['href']} has no dateCreated or datePublished"
+                )
+            pub_date = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+            if pub_date < since:
+                return None
+
+        # Pick the single matching item and download it.
+        matches = [
+            item
+            for linkset in linksets
+            for item in linkset.get("item", [])
+            if select_func(item)
+        ]
+        if len(matches) != 1:
+            raise DOIFileFetchError(
+                f"Expected 1 matching linkset item at {doi}, got {len(matches)}"
+            )
+        file_resp = session.get(matches[0]["href"])
+        file_resp.raise_for_status()
+        return file_resp.content

--- a/tests/contrib/affiliations/test_affiliations_datastreams.py
+++ b/tests/contrib/affiliations/test_affiliations_datastreams.py
@@ -87,6 +87,7 @@ def expected_from_ror_json():
             {"scheme": "isni", "identifier": "0000 0001 0706 8890"},
         ],
         "types": ["education", "funder"],
+        "website": "http://www.caltech.edu/",
     }
 
 

--- a/tests/contrib/awards/conftest.py
+++ b/tests/contrib/awards/conftest.py
@@ -12,6 +12,7 @@ from invenio_i18n import lazy_gettext as _
 from invenio_indexer.proxies import current_indexer_registry
 from invenio_records_resources.proxies import current_service_registry
 
+from invenio_vocabularies.contrib.affiliations.api import Affiliation
 from invenio_vocabularies.contrib.awards.api import Award
 from invenio_vocabularies.contrib.funders.api import Funder
 
@@ -66,6 +67,36 @@ def funders_service():
 def funder_indexer():
     """Indexer instance with correct Record class."""
     return current_indexer_registry.get("funders")
+
+
+#
+# Affiliation related fixtures
+#
+@pytest.fixture(scope="module")
+def affiliations_service():
+    """Affiliations service object."""
+    return current_service_registry.get("affiliations")
+
+
+@pytest.fixture(scope="function")
+def example_affiliation(db, identity, affiliations_service):
+    """Example affiliation used to test award.organizations dereferencing."""
+    affiliation = affiliations_service.create(
+        identity,
+        {
+            "id": "01ggx4157",
+            "name": "CERN",
+            "acronym": "CERN",
+            "identifiers": [
+                {"identifier": "01ggx4157", "scheme": "ror"},
+            ],
+        },
+    )
+    Affiliation.index.refresh()
+    yield affiliation
+    affiliation._record.delete(force=True)
+    affiliations_service.indexer.delete(affiliation._record, refresh=True)
+    db.session.commit()
 
 
 #

--- a/tests/contrib/awards/test_awards_datastreams.py
+++ b/tests/contrib/awards/test_awards_datastreams.py
@@ -11,11 +11,12 @@ from invenio_access.permissions import system_identity
 from invenio_vocabularies.contrib.awards.api import Award
 from invenio_vocabularies.contrib.awards.datastreams import (
     AwardsServiceWriter,
+    CORDISAwardsServiceWriter,
     CORDISProjectTransformer,
     OpenAIREProjectTransformer,
 )
 from invenio_vocabularies.datastreams import StreamEntry
-from invenio_vocabularies.datastreams.errors import WriterError
+from invenio_vocabularies.datastreams.errors import TransformerError, WriterError
 from invenio_vocabularies.datastreams.readers import XMLReader
 
 
@@ -176,13 +177,7 @@ def expected_from_cordis_project_xml():
         "id": "00k4n6c32::101117736",
         "program": "HORIZON.1.1",
         "subjects": [{"id": "euroscivoc:225"}],
-        "organizations": [
-            {
-                "id": "999979888",
-                "scheme": "pic",
-                "organization": "TECHNISCHE UNIVERSITAET WIEN",
-            }
-        ],
+        "organizations": [{"organization": "TECHNISCHE UNIVERSITAET WIEN"}],
     }
 
 
@@ -314,12 +309,152 @@ def test_awards_service_writer_update_non_existing(
     award_rec._record.delete(force=True)
 
 
-def test_awards_cordis_transformer(expected_from_cordis_project_xml):
+def test_awards_cordis_transformer(app, expected_from_cordis_project_xml):
     """Validate transformation of CORDIS project XML to expected format."""
     reader = XMLReader()
     award = next(reader.read(CORDIS_PROJECT_XML))
 
-    cordis_transformer = CORDISProjectTransformer()
+    cordis_transformer = CORDISProjectTransformer(pic_mapping={})
     transformed_award_data = cordis_transformer.apply(StreamEntry(award["project"]))
 
     assert transformed_award_data.entry == expected_from_cordis_project_xml
+
+
+def test_awards_cordis_transformer_resolves_pic_to_ror(app):
+    """When the PIC is in the resolution map, the org becomes a ROR-id relation."""
+    reader = XMLReader()
+    award = next(reader.read(CORDIS_PROJECT_XML))
+
+    pic_mapping = {"999979888": "04d836q62"}
+    cordis_transformer = CORDISProjectTransformer(pic_mapping=pic_mapping)
+    transformed = cordis_transformer.apply(StreamEntry(award["project"]))
+
+    assert transformed.entry["organizations"] == [{"id": "04d836q62"}]
+
+
+def test_awards_cordis_transformer_unresolved_pic_keeps_name_only(app):
+    """Unresolved PICs are stored by name only (no `id`, so `PIDListRelation` won't resolve them)."""
+    reader = XMLReader()
+    award = next(reader.read(CORDIS_PROJECT_XML))
+
+    cordis_transformer = CORDISProjectTransformer(
+        pic_mapping={"other-pic": "01abc1234"}
+    )
+    transformed = cordis_transformer.apply(StreamEntry(award["project"]))
+
+    assert transformed.entry["organizations"] == [
+        {"organization": "TECHNISCHE UNIVERSITAET WIEN"}
+    ]
+
+
+PIC_MAPPING_CSV = """\
+pic,ror_id,confidence,source
+111,01high1111,high,openaire_direct
+222,02med22222,medium,openaire_external
+333,03review33,review,participant_name_country
+444,04manual44,manual,manual_override
+555,,high,openaire_direct
+,06nopic666,high,openaire_direct
+"""
+
+
+def test_load_pic_mapping_filters_confidence(tmp_path):
+    """Rows with confidence not in the accepted set are dropped."""
+    csv_path = tmp_path / "pic_mapping.csv"
+    csv_path.write_text(PIC_MAPPING_CSV)
+
+    params = CORDISProjectTransformer.pic_mapping_params
+    mapping = CORDISProjectTransformer._load_pic_mapping(
+        str(csv_path),
+        filename=params["filename"],
+        accepted_confidence=params["accepted_confidence"],
+    )
+
+    assert mapping == {"111": "01high1111", "222": "02med22222", "444": "04manual44"}
+
+
+def test_load_pic_mapping_missing_file_raises(tmp_path):
+    """Missing mapping CSV is a hard error; fail fast on misconfiguration."""
+    params = CORDISProjectTransformer.pic_mapping_params
+    with pytest.raises(TransformerError):
+        CORDISProjectTransformer._load_pic_mapping(
+            str(tmp_path / "pic_mapping.csv"),
+            filename=params["filename"],
+            accepted_confidence=params["accepted_confidence"],
+        )
+
+
+@pytest.fixture(scope="function")
+def example_euroscivoc_subject(db, identity):
+    """euroscivoc:225 subject required by the CORDIS test XML."""
+    from invenio_records_resources.proxies import current_service_registry
+
+    from invenio_vocabularies.contrib.subjects.api import Subject
+
+    subjects_service = current_service_registry.get("subjects")
+    subject = subjects_service.create(
+        identity,
+        {
+            "id": "euroscivoc:225",
+            "scheme": "EuroSciVoc",
+            "subject": "oncology",
+        },
+    )
+    Subject.index.refresh()
+    yield subject
+    subject._record.delete(force=True)
+    db.session.commit()
+
+
+def test_cordis_datastream_end_to_end_pic_resolves(
+    app,
+    db,
+    search_clear,
+    service,
+    identity,
+    example_funder_ec,
+    example_affiliation,
+    example_euroscivoc_subject,
+    tmp_path,
+):
+    """End-to-end CORDIS update: PIC -> ROR map loaded from local config,
+    transformer emits a vocabulary relation, writer updates the award, and
+    the read view dereferences `organizations` against the affiliations vocab.
+    """
+    # Baseline award (CORDIS is update-only).
+    baseline_id = "00k4n6c32::101117736"
+    service.create(
+        identity,
+        {
+            "id": baseline_id,
+            "number": "101117736",
+            "title": {"en": "Time2SWITCH"},
+            "funder": {"id": "00k4n6c32"},
+        },
+    )
+    Award.index.refresh()
+
+    # Local PIC -> ROR map: PIC from CORDIS_PROJECT_XML resolves to the
+    # `example_affiliation` ROR id (01ggx4157, CERN).
+    csv_path = tmp_path / "pic_mapping.csv"
+    csv_path.write_text(
+        "pic,ror_id,confidence,source\n" "999979888,01ggx4157,high,openaire_direct\n"
+    )
+    app.config["VOCABULARIES_AWARDS_PIC_MAPPING_SOURCE"] = str(csv_path)
+
+    # Run the real readers/transformer/writer chain on the fixture XML.
+    award = next(XMLReader().read(CORDIS_PROJECT_XML))
+    transformer = CORDISProjectTransformer()
+    writer = CORDISAwardsServiceWriter()
+    transformed = transformer.apply(StreamEntry(award["project"]))
+    writer.write(transformed)
+    Award.index.refresh()
+
+    read_item = service.read(identity, baseline_id)
+    assert read_item["organizations"] == [
+        {
+            "id": "01ggx4157",
+            "name": "CERN",
+            "identifiers": [{"identifier": "01ggx4157", "scheme": "ror"}],
+        }
+    ]

--- a/tests/contrib/awards/test_awards_datastreams.py
+++ b/tests/contrib/awards/test_awards_datastreams.py
@@ -122,6 +122,12 @@ CORDIS_PROJECT_XML = bytes(
 	<identifiers>
 		<grantDoi>10.3030/101117736</grantDoi>
 	</identifiers>
+	<teaser>I envision a new drug delivery system capable spatiotemporal release with electronic precision.This technology is based on; Biontronic Chemistry (BC) which combines Bioorthogonal Release (BR) and Iontronic transport to overcome the drawbacks of each individual technology and...</teaser>
+	<objective>I envision a new drug delivery system capable spatiotemporal release with electronic precision.
+This technology is based on; Biontronic Chemistry (BC) which combines Bioorthogonal Release (BR) and Iontronic transport to overcome the drawbacks of each individual technology and combine their unique advantages.</objective>
+	<title>Bioorthogonal Iontronic Chemistry: Spatiotemporal Drug Release with Electronic Precision</title>
+	<startDate>2024-09-01</startDate>
+	<endDate>2029-08-31</endDate>
 	<relations>
 		<associations>
 			<organization type="coordinator" source="corda" order="1" ecContribution="1496795" terminated="false" sme="false" netEcContribution="1496795" totalCost="1496795">
@@ -175,6 +181,27 @@ CORDIS_PROJECT_XML = bytes(
 def expected_from_cordis_project_xml():
     return {
         "id": "00k4n6c32::101117736",
+        "funder": {"id": "00k4n6c32"},
+        "number": "101117736",
+        "identifiers": [
+            {
+                "identifier": "https://cordis.europa.eu/projects/101117736",
+                "scheme": "url",
+            },
+        ],
+        "title": {
+            "en": "Bioorthogonal Iontronic Chemistry: Spatiotemporal Drug Release with Electronic Precision"
+        },
+        "acronym": "Time2SWITCH",
+        "start_date": "2024-09-01",
+        "end_date": "2029-08-31",
+        "description": {
+            "en": """I envision a new drug delivery system capable spatiotemporal release with electronic precision.
+This technology is based on; Biontronic Chemistry (BC) which combines Bioorthogonal Release (BR) and Iontronic transport to overcome the drawbacks of each individual technology and combine their unique advantages."""
+        },
+        "short_description": {
+            "en": "I envision a new drug delivery system capable spatiotemporal release with electronic precision.This technology is based on; Biontronic Chemistry (BC) which combines Bioorthogonal Release (BR) and Iontronic transport to overcome the drawbacks of each "
+        },
         "program": "HORIZON.1.1",
         "subjects": [{"id": "euroscivoc:225"}],
         "organizations": [{"name": "TECHNISCHE UNIVERSITAET WIEN"}],

--- a/tests/contrib/awards/test_awards_datastreams.py
+++ b/tests/contrib/awards/test_awards_datastreams.py
@@ -188,6 +188,10 @@ def expected_from_cordis_project_xml():
                 "identifier": "https://cordis.europa.eu/projects/101117736",
                 "scheme": "url",
             },
+            {
+                "identifier": "10.3030/101117736",
+                "scheme": "doi",
+            },
         ],
         "title": {
             "en": "Bioorthogonal Iontronic Chemistry: Spatiotemporal Drug Release with Electronic Precision"

--- a/tests/contrib/awards/test_awards_datastreams.py
+++ b/tests/contrib/awards/test_awards_datastreams.py
@@ -177,7 +177,7 @@ def expected_from_cordis_project_xml():
         "id": "00k4n6c32::101117736",
         "program": "HORIZON.1.1",
         "subjects": [{"id": "euroscivoc:225"}],
-        "organizations": [{"organization": "TECHNISCHE UNIVERSITAET WIEN"}],
+        "organizations": [{"name": "TECHNISCHE UNIVERSITAET WIEN"}],
     }
 
 
@@ -343,7 +343,7 @@ def test_awards_cordis_transformer_unresolved_pic_keeps_name_only(app):
     transformed = cordis_transformer.apply(StreamEntry(award["project"]))
 
     assert transformed.entry["organizations"] == [
-        {"organization": "TECHNISCHE UNIVERSITAET WIEN"}
+        {"name": "TECHNISCHE UNIVERSITAET WIEN"}
     ]
 
 

--- a/tests/contrib/awards/test_awards_service.py
+++ b/tests/contrib/awards/test_awards_service.py
@@ -120,6 +120,37 @@ def test_award_dereferenced(
     assert list(res.hits)[0]["funder"] == expected_funder
 
 
+def test_award_organizations_dereferenced(
+    app,
+    search_clear,
+    service,
+    identity,
+    award_full_data,
+    example_funder_ec,
+    example_affiliation,
+):
+    """Award organizations resolve against the affiliations vocabulary."""
+    award_full_data["organizations"] = [{"id": "01ggx4157"}]
+
+    item = service.create(identity, award_full_data)
+    Award.index.refresh()
+    id_ = item.id
+
+    expected_organization = {
+        "id": "01ggx4157",
+        "name": "CERN",
+        "identifiers": [{"identifier": "01ggx4157", "scheme": "ror"}],
+    }
+    assert item["organizations"] == [expected_organization]
+
+    read_item = service.read(identity, id_)
+    assert read_item["organizations"] == [expected_organization]
+
+    res = service.search(identity, q=f"id:{id_}", size=25, page=1)
+    assert res.total == 1
+    assert list(res.hits)[0]["organizations"] == [expected_organization]
+
+
 def test_indexed_at_query(
     app, db, service, identity, award_full_data, example_funder_ec
 ):

--- a/tests/contrib/awards/test_awards_service.py
+++ b/tests/contrib/awards/test_awards_service.py
@@ -151,6 +151,38 @@ def test_award_organizations_dereferenced(
     assert list(res.hits)[0]["organizations"] == [expected_organization]
 
 
+def test_award_organizations_free_text(
+    app,
+    search_clear,
+    service,
+    identity,
+    award_full_data,
+    example_funder_ec,
+):
+    """Free-text organizations are accepted via `name` and the legacy `organization` key."""
+    award_full_data["organizations"] = [
+        {"name": "New Org"},
+        {"organization": "Legacy Org"},
+    ]
+
+    item = service.create(identity, award_full_data)
+    Award.index.refresh()
+    id_ = item.id
+
+    read_item = service.read(identity, id_)
+    assert read_item["organizations"] == [
+        {"name": "New Org"},
+        {"organization": "Legacy Org"},
+    ]
+
+    res = service.search(identity, q=f"id:{id_}", size=25, page=1)
+    assert res.total == 1
+    assert list(res.hits)[0]["organizations"] == [
+        {"name": "New Org"},
+        {"organization": "Legacy Org"},
+    ]
+
+
 def test_indexed_at_query(
     app, db, service, identity, award_full_data, example_funder_ec
 ):

--- a/tests/contrib/common/openaire/test_openaire_datastreams.py
+++ b/tests/contrib/common/openaire/test_openaire_datastreams.py
@@ -70,6 +70,7 @@ DOWNLOAD_FILE_BYTES_CONTENT = b"The content of the file"
 
 class MockResponse:
     content = DOWNLOAD_FILE_BYTES_CONTENT
+    links = {"linkset": {"url": "https://example.com/api/records/10488385"}}
 
     def __init__(self, api_json_response_content):
         self.api_json_response_content = api_json_response_content
@@ -87,8 +88,10 @@ def download_file_bytes_content():
 
 
 @patch(
-    "requests.get",
-    side_effect=lambda url, headers=None: MockResponse(API_JSON_RESPONSE_CONTENT),
+    "requests.Session.get",
+    side_effect=lambda url, headers=None, **kwargs: MockResponse(
+        API_JSON_RESPONSE_CONTENT
+    ),
 )
 def test_openaire_http_reader(_, download_file_bytes_content):
     reader = OpenAIREHTTPReader(
@@ -104,8 +107,8 @@ def test_openaire_http_reader(_, download_file_bytes_content):
 
 
 @patch(
-    "requests.get",
-    side_effect=lambda url, headers=None: MockResponse(
+    "requests.Session.get",
+    side_effect=lambda url, headers=None, **kwargs: MockResponse(
         API_JSON_RESPONSE_CONTENT_WRONG_NUMBER_PROJECT_TAR_ITEMS_ERROR
     ),
 )

--- a/tests/contrib/common/ror/test_ror_datastreams.py
+++ b/tests/contrib/common/ror/test_ror_datastreams.py
@@ -162,7 +162,7 @@ def side_effect(url, headers=None, allow_redirects=False):
         return MockResponse({})
 
 
-@patch("requests.get", side_effect=side_effect)
+@patch("requests.Session.get", side_effect=side_effect)
 def test_ror_http_reader(_):
     reader = RORHTTPReader()
     results = []
@@ -176,7 +176,7 @@ def test_ror_http_reader(_):
     assert results[0].read() == DOWNLOAD_FILE_BYTES_CONTENT
 
 
-@patch("requests.get", side_effect=side_effect)
+@patch("requests.Session.get", side_effect=side_effect)
 def test_ror_http_reader_since_before_publish(_):
     reader = RORHTTPReader(since="2024-07-10T00:00:00.000+00:00")
     results = []
@@ -188,7 +188,7 @@ def test_ror_http_reader_since_before_publish(_):
     assert len(results) == 1
 
 
-@patch("requests.get", side_effect=side_effect)
+@patch("requests.Session.get", side_effect=side_effect)
 def test_ror_http_reader_since_after_publish(_):
     reader = RORHTTPReader(since="2024-07-12T00:00:00.000+00:00")
     results = []
@@ -201,7 +201,7 @@ def test_ror_http_reader_since_after_publish(_):
 
 
 @patch(
-    "requests.get",
+    "requests.Session.get",
     side_effect=lambda url, headers=None, allow_redirects=False: MockResponse(
         API_JSON_RESPONSE_CONTENT_WRONG_NUMBER_ZIP_ITEMS_ERROR
     ),
@@ -213,7 +213,7 @@ def test_ror_http_reader_wrong_number_zip_items_error(_):
 
 
 @patch(
-    "requests.get",
+    "requests.Session.get",
     side_effect=lambda url, headers=None, allow_redirects=False: MockResponse(
         API_JSON_RESPONSE_CONTENT_WITHOUT_JSON_LD
     ),

--- a/tests/contrib/common/ror/test_ror_datastreams.py
+++ b/tests/contrib/common/ror/test_ror_datastreams.py
@@ -132,6 +132,7 @@ def expected_from_ror_json():
             {"scheme": "ror", "identifier": "05dxps055"},
         ],
         "types": ["education", "funder"],
+        "website": "http://www.caltech.edu/",
     }
 
 

--- a/tests/contrib/funders/test_funders_datastreams.py
+++ b/tests/contrib/funders/test_funders_datastreams.py
@@ -42,6 +42,7 @@ def expected_from_ror_json():
             {"scheme": "isni", "identifier": "0000 0001 0706 8890"},
         ],
         "types": ["education", "funder"],
+        "website": "http://www.caltech.edu/",
     }
 
 


### PR DESCRIPTION
- Added short description field from CORDIS to awards datastream
- Added PIC to ROR mapping-based resolution for CORDIS organizations

See https://github.com/zenodo/cordis-pic-ror for [PIC-to-ROR mapping file](https://github.com/zenodo/cordis-pic-ror/blob/main/output/pic_mapping.csv) (to be uploaded as a Zenodo record).

To use this new import, you have to:

```shell
# 1. Set in your config `VOCABULARIES_AWARDS_PIC_MAPPING_SOURCE = "/path/to/pic_mapping.csv"`

# 2. Import ROR affiliations first
invenio vocabularies import --vocabulary affiliations

# 3. Import CORDIS awards
invenio vocabularies import --vocabulary awards:cordis --origin HE
```