### PR TITLE
fix(datastreams): Log ORCID read errors as warnings

### DIFF
--- a/invenio_vocabularies/contrib/names/datastreams.py
+++ b/invenio_vocabularies/contrib/names/datastreams.py
@@ -54,7 +54,7 @@ class OrcidDataSyncReader(BaseReader):
             # and choose the sections we need to read (probably the summary)
             return self.s3_client.read_file(f"s3://{bucket}/{key}")
         except Exception:
-            app.logger.exception(f"Failed to fetch ORCiD record: {key}")
+            app.logger.exception("Failed to fetch ORCiD record: %s", key)
 
     def _process_lambda_file(self, fileobj):
         """Process the ORCiD lambda file and returns a list of ORCiDs to sync.
@@ -135,7 +135,7 @@ class OrcidDataSyncReader(BaseReader):
                         yield result
                 except Exception:
                     current_app.logger.warning(
-                        f"Error processing ORCiD record: {orcid}"
+                        "Error processing ORCiD record: %s", orcid
                     )
                 finally:
                     # Explicitly release memory, as we don't need the future anymore.

--- a/invenio_vocabularies/contrib/names/datastreams.py
+++ b/invenio_vocabularies/contrib/names/datastreams.py
@@ -134,7 +134,7 @@ class OrcidDataSyncReader(BaseReader):
                         )
                         yield result
                 except Exception:
-                    current_app.logger.exception(
+                    current_app.logger.warning(
                         f"Error processing ORCiD record: {orcid}"
                     )
                 finally:
@@ -366,7 +366,7 @@ class OrcidTransformer(BaseTransformer):
 
                 result.append(aff)
         except Exception:
-            current_app.logger.error("Error extracting affiliations.")
+            current_app.logger.warning("Error extracting affiliations.")
         return result
 
     def _extract_affiliation_id(self, org):

--- a/invenio_vocabularies/datastreams/datastreams.py
+++ b/invenio_vocabularies/datastreams/datastreams.py
@@ -45,9 +45,11 @@ class StreamEntry:
         if logger is None:
             logger = current_app.logger
         for error in self.errors:
-            logger.error(f"Error in entry {self.entry}: {error}")
+            # Warning to avoid Sentry spam, as we are anyways attaching the error to the StreamEntry
+            logger.warning(f"Error in entry {self.entry}: {error}")
         if self.exc:
-            logger.error(f"Exception in entry {self.entry}: {self.exc}")
+            # Exception to log the full stack trace
+            logger.exception(f"Exception in entry {self.entry}: {self.exc}")
 
 
 class DataStream:
@@ -95,9 +97,6 @@ class DataStream:
         transformed_entries_with_errors = []
         for stream_entry in batch:
             if stream_entry.errors:
-                current_app.logger.warning(
-                    f"Skipping entry with errors: {stream_entry.errors}"
-                )
                 yield stream_entry  # reading errors
             else:
                 transformed_entry = self.transform(stream_entry)
@@ -158,7 +157,6 @@ class DataStream:
                     else:
                         yield StreamEntry(item)
                 except ReaderError as err:
-                    current_app.logger.error(f"Reader error: {str(err)}")
                     yield StreamEntry(
                         entry=item,
                         errors=[f"{current_gen_func.__qualname__}: {str(err)}"],
@@ -212,6 +210,7 @@ class DataStream:
                 else:
                     writer.write(stream_entry)
             except WriterError as err:
+                # The actionable bugs are logged as errors to send to Sentry
                 current_app.logger.error(f"Writer error: {str(err)}")
                 stream_entry.errors.append(f"{writer.__class__.__name__}: {str(err)}")
 
@@ -230,6 +229,7 @@ class DataStream:
                 else:
                     yield from writer.write_many(stream_entries)
             except WriterError as err:
+                # The actionable bugs are logged as errors to send to Sentry
                 current_app.logger.error(f"Writer error: {str(err)}")
                 for entry in stream_entries:
                     entry.errors.append(f"{writer.__class__.__name__}: {str(err)}")

--- a/invenio_vocabularies/datastreams/datastreams.py
+++ b/invenio_vocabularies/datastreams/datastreams.py
@@ -46,10 +46,14 @@ class StreamEntry:
             logger = current_app.logger
         for error in self.errors:
             # Warning to avoid Sentry spam, as we are anyways attaching the error to the StreamEntry
-            logger.warning(f"Error in entry {self.entry}: {error}")
+            logger.warning("Error in entry: %s", error, extra={"entry": self.entry})
         if self.exc:
             # Exception to log the full stack trace
-            logger.exception(f"Exception in entry {self.entry}: {self.exc}")
+            logger.exception(
+                "Exception in entry: %s",
+                self.exc,
+                extra={"entry": self.entry, "exception": self.exc},
+            )
 
 
 class DataStream:
@@ -110,7 +114,8 @@ class DataStream:
                     transformed_entries.append(transformed_entry)
         if transformed_entries_with_errors:
             current_app.logger.warning(
-                f"Skipping {len(transformed_entries_with_errors)} transformed entries with errors."
+                "Skipping %s transformed entries with errors.",
+                len(transformed_entries_with_errors),
             )
         if transformed_entries:
             if self.write_many:
@@ -211,7 +216,9 @@ class DataStream:
                     writer.write(stream_entry)
             except WriterError as err:
                 # The actionable bugs are logged as errors to send to Sentry
-                current_app.logger.error(f"Writer error: {str(err)}")
+                current_app.logger.error(
+                    "Writer error: %s", str(err), extra={"entry": stream_entry.entry}
+                )
                 stream_entry.errors.append(f"{writer.__class__.__name__}: {str(err)}")
 
         return stream_entry
@@ -230,7 +237,7 @@ class DataStream:
                     yield from writer.write_many(stream_entries)
             except WriterError as err:
                 # The actionable bugs are logged as errors to send to Sentry
-                current_app.logger.error(f"Writer error: {str(err)}")
+                current_app.logger.error("Writer error: %s", str(err))
                 for entry in stream_entries:
                     entry.errors.append(f"{writer.__class__.__name__}: {str(err)}")
 

--- a/invenio_vocabularies/datastreams/tasks.py
+++ b/invenio_vocabularies/datastreams/tasks.py
@@ -52,6 +52,7 @@ def write_entry(writer_config, entry, subtask_run_id=None):
                 updated_entries_count=updated_count,
             )
     except Exception as exc:
+        # The actionable bugs are logged as errors to send to Sentry
         current_app.logger.error(f"Error writing entry {entry}: {exc}")
         if subtask_run_id and job_id:
             current_runs_service.finalize_subtask(
@@ -103,8 +104,8 @@ def write_many_entry(writer_config, entries, subtask_run_id=None):
                 updated_entries_count=updated_count,
             )
     except Exception as exc:
-        current_app.logger.error(
-            f"Error writing entries {entries}: {exc}. The errorred entries count might be incorrect as an entire batch might have failed"
+        current_app.logger.warning(
+            f"Error writing entries {entries}: {repr(exc)}. The errorred entries count might be incorrect as an entire batch might have failed"
         )
         if subtask_run_id and job_id:
             current_runs_service.finalize_subtask(

--- a/invenio_vocabularies/datastreams/tasks.py
+++ b/invenio_vocabularies/datastreams/tasks.py
@@ -53,7 +53,7 @@ def write_entry(writer_config, entry, subtask_run_id=None):
             )
     except Exception as exc:
         # The actionable bugs are logged as errors to send to Sentry
-        current_app.logger.error(f"Error writing entry {entry}: {exc}")
+        current_app.logger.error("Error writing entry: %s", exc, extra={"entry": entry})
         if subtask_run_id and job_id:
             current_runs_service.finalize_subtask(
                 system_identity,
@@ -105,7 +105,9 @@ def write_many_entry(writer_config, entries, subtask_run_id=None):
             )
     except Exception as exc:
         current_app.logger.warning(
-            f"Error writing entries {entries}: {repr(exc)}. The errorred entries count might be incorrect as an entire batch might have failed"
+            "Error writing entries %s: %s. The errorred entries count might be incorrect as an entire batch might have failed",
+            entries,
+            repr(exc),
         )
         if subtask_run_id and job_id:
             current_runs_service.finalize_subtask(

--- a/invenio_vocabularies/datastreams/writers.py
+++ b/invenio_vocabularies/datastreams/writers.py
@@ -134,7 +134,18 @@ class ServiceWriter(BaseWriter):
         """Writes the input entries using a given service."""
         current_app.logger.info(f"Writing {len(stream_entries)} entries")
         entries = [entry.entry for entry in stream_entries]
-        entries_with_id = [(self._entry_id(entry), entry) for entry in entries]
+        entries_with_id = []
+        entries_without_id = []
+        for entry in entries:
+            try:
+                entries_with_id.append((self._entry_id(entry), entry))
+            except KeyError:
+                # While reading the entries, we might not have the ID in the entry, so we skip them instead of erroring out the whole batch
+                entries_without_id.append(entry)
+        if entries_without_id:
+            current_app.logger.warning(
+                f"Skipping {len(entries_without_id)} entries without ID: {entries_without_id}"
+            )
         result_list = self._service.create_or_update_many(
             self._identity, entries_with_id
         )

--- a/invenio_vocabularies/datastreams/writers.py
+++ b/invenio_vocabularies/datastreams/writers.py
@@ -144,7 +144,9 @@ class ServiceWriter(BaseWriter):
                 entries_without_id.append(entry)
         if entries_without_id:
             current_app.logger.warning(
-                f"Skipping {len(entries_without_id)} entries without ID: {entries_without_id}"
+                "Skipping %s entries without ID: %s",
+                len(entries_without_id),
+                entries_without_id,
             )
         result_list = self._service.create_or_update_many(
             self._identity, entries_with_id

--- a/invenio_vocabularies/services/tasks.py
+++ b/invenio_vocabularies/services/tasks.py
@@ -27,12 +27,13 @@ def process_datastream(config):
     entries_with_errors = 0
     for result in ds.process():
         if result.errors:
-            for err in result.errors:
-                current_app.logger.error(err)
+            current_app.logger.warning(
+                f"Skipped entry {result.entry} with errors: {result.errors}"
+            )
             entries_with_errors += 1
 
     if entries_with_errors:
         raise TaskExecutionPartialError(
-            message=f"Task execution succeeded with {entries_with_errors} entries with errors.",
+            message=f"Task execution partially succeeded with {entries_with_errors} entries with errors.",
             errored_entries_count=entries_with_errors,
         )

--- a/invenio_vocabularies/services/tasks.py
+++ b/invenio_vocabularies/services/tasks.py
@@ -28,7 +28,7 @@ def process_datastream(config):
     for result in ds.process():
         if result.errors:
             current_app.logger.warning(
-                f"Skipped entry {result.entry} with errors: {result.errors}"
+                "Skipped entry %s with errors: %s", result.entry, result.errors
             )
             entries_with_errors += 1
 


### PR DESCRIPTION
Fixes: #511 

* This will fix the issue of read errors getting logged to sentry due to wrongly being marked as errors. Because we should only mark issues as ERROR/EXCEPTION when there are bugs in the code but most read errors are due to the data from ORCID being incomplete
