### PR TITLE
fix(contrib): adding custom funders

### DIFF
--- a/invenio_vocabularies/assets/semantic-ui/js/invenio_vocabularies/src/contrib/forms/Funding/CustomAwardForm.js
+++ b/invenio_vocabularies/assets/semantic-ui/js/invenio_vocabularies/src/contrib/forms/Funding/CustomAwardForm.js
@@ -1,6 +1,7 @@
 // This file is part of InvenioVocabularies
 // Copyright (C) 2021-2024 CERN.
 // Copyright (C) 2021 Northwestern University.
+// Copyright (C) 2026 ZBW – Leibniz-Informationszentrum Wirtschaft.
 //
 // Invenio is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
@@ -11,6 +12,7 @@ import { Form, Header } from "semantic-ui-react";
 import { TextField, RemoteSelectField } from "react-invenio-forms";
 import { i18next } from "@translations/invenio_vocabularies/i18next";
 import _isEmpty from "lodash/isEmpty";
+import { Field, getIn } from "formik";
 
 import Overridable from "react-overridable";
 
@@ -23,69 +25,124 @@ function CustomAwardForm({ deserializeFunder, selectedFunding }) {
     if (!funderName && !funderPID) {
       return {};
     }
+    const isVocabFunder = funderPID;
+    const funderText = [funderName, funderCountry, funderPID]
+      .filter(Boolean)
+      .join(", ");
+
+    const dropdownContent = isVocabFunder ? (
+      <div className="ui header">
+        {funderName} (
+        <span>
+          <a
+            href={`https://ror.org/${funderPID}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <img
+              alt={i18next.t("ROR logo")}
+              src="/static/images/ror-icon.svg"
+              className="inline-id-icon mr-5"
+            />
+            {funderPID}
+          </a>
+        </span>
+        ){funderCountry && <div className="sub header">{funderCountry}</div>}
+      </div>
+    ) : null;
 
     return {
-      text: [funderName, funderCountry, funderPID].filter((val) => val).join(", "),
-      value: funderItem.id,
-      key: funderItem.id,
+      id: funderPID,
+      // Used when selected
+      text: funderText,
+      // Used in dropdown list
+      content: dropdownContent || funderText,
+      value: funderPID || funderName,
+      key: funderPID || funderName,
       ...(funderName && { name: funderName }),
       ...(funderPID && { pid: funderPID }),
     };
   }
-
   function serializeFunderFromDropdown(funderDropObject) {
-    return {
-      id: funderDropObject.key,
-      ...(funderDropObject.name && { name: funderDropObject.name }),
-      ...(funderDropObject.pid && { pid: funderDropObject.pid }),
-    };
+    const isVocabFunder = funderDropObject.id;
+
+    let result;
+    if (isVocabFunder) {
+      result = {
+        id: funderDropObject.id,
+        name: funderDropObject.name,
+        ...(funderDropObject.name && { name: funderDropObject.name }),
+        ...(funderDropObject.pid && { pid: funderDropObject.pid }),
+      };
+    } else {
+      result = {
+        name: funderDropObject.name,
+      };
+    }
+    return result;
   }
 
   return (
     <Form>
-      <Overridable
-        id="InvenioVocabularies.CustomAwardForm.RemoteSelectField.Container"
-        fieldPath="selectedFunding.funder.id"
-      >
-        <RemoteSelectField
-          fieldPath="selectedFunding.funder.id"
-          suggestionAPIUrl="/api/funders"
-          suggestionAPIHeaders={{
-            Accept: "application/vnd.inveniordm.v1+json",
-          }}
-          placeholder={i18next.t("Search for a funder by name")}
-          serializeSuggestions={(funders) => {
-            return funders.map((funder) =>
-              deserializeFunderToDropdown(deserializeFunder(funder))
-            );
-          }}
-          searchInput={{
-            autoFocus: _isEmpty(selectedFunding),
-          }}
-          label={i18next.t("Funder")}
-          noQueryMessage={i18next.t("Search for funder...")}
-          clearable
-          allowAdditions={false}
-          multiple={false}
-          selectOnBlur={false}
-          selectOnNavigation={false}
-          required
-          search={(options) => options}
-          isFocused
-          onValueChange={({ formikProps }, selectedFundersArray) => {
-            if (selectedFundersArray.length === 1) {
-              const selectedFunder = selectedFundersArray[0];
-              if (selectedFunder) {
-                const deserializedFunder = serializeFunderFromDropdown(selectedFunder);
-                formikProps.form.setFieldValue(
-                  "selectedFunding.funder",
-                  deserializedFunder
-                );
-              }
-            }
-          }}
-        />
-      </Overridable>
+      <Field name="selectedFunding.funder">
+        {({ form: { values, setFieldValue } }) => {
+          const currentFunder = getIn(values, "selectedFunding.funder");
+
+          const initialSuggestions = currentFunder
+            ? [deserializeFunderToDropdown(currentFunder)]
+            : [];
+
+          return (
+            <Overridable
+              id="InvenioVocabularies.CustomAwardForm.RemoteSelectField.Container"
+              fieldPath="selectedFunding.funder"
+            >
+              <RemoteSelectField
+                fieldPath="selectedFunding.funder"
+                suggestionAPIUrl="/api/funders"
+                suggestionAPIHeaders={{
+                  Accept: "application/vnd.inveniordm.v1+json",
+                }}
+                placeholder={i18next.t("Search or create funder")}
+                serializeSuggestions={(funders) => {
+                  return funders.map((funder) =>
+                    deserializeFunderToDropdown(deserializeFunder(funder))
+                  );
+                }}
+                initialSuggestions={initialSuggestions}
+                searchInput={{
+                  autoFocus: _isEmpty(selectedFunding),
+                }}
+                label={i18next.t("Funder")}
+                noQueryMessage={i18next.t("Search for funder...")}
+                clearable
+                allowAdditions
+                multiple={false}
+                selectOnBlur={false}
+                selectOnNavigation={false}
+                required
+                value={currentFunder?.id || currentFunder?.name || ""}
+                isFocused={currentFunder ? false : true}
+                onValueChange={({ formikProps }, selectedFundersArray) => {
+                  if (selectedFundersArray.length === 1) {
+                    const selectedFunder = selectedFundersArray[0];
+                    if (selectedFunder) {
+                      const deserializedFunder =
+                        serializeFunderFromDropdown(selectedFunder);
+                      formikProps.form.setFieldValue(
+                        "selectedFunding.funder",
+                        deserializedFunder
+                      );
+                    }
+                  } else {
+                    setFieldValue("selectedFunding.funder", undefined);
+                  }
+                }}
+              />
+            </Overridable>
+          );
+        }}
+      </Field>
       <Overridable id="InvenioVocabularies.CustomAwardForm.AwardInformationHeader.Container">
         <Header as="h3" size="small">
           {i18next.t("Additional information")} ({i18next.t("optional")})

--- a/invenio_vocabularies/assets/semantic-ui/js/invenio_vocabularies/src/contrib/forms/Funding/CustomAwardForm.js
+++ b/invenio_vocabularies/assets/semantic-ui/js/invenio_vocabularies/src/contrib/forms/Funding/CustomAwardForm.js
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2021-2024 CERN.
  * SPDX-FileCopyrightText: 2021 Northwestern University.
+ * SPDX-FileCopyrightText: 2026 ZBW – Leibniz-Informationszentrum Wirtschaft.
  * SPDX-License-Identifier: MIT
  */
 
@@ -10,6 +11,7 @@ import { Form, Header } from "semantic-ui-react";
 import { TextField, RemoteSelectField } from "react-invenio-forms";
 import { i18next } from "@translations/invenio_vocabularies/i18next";
 import _isEmpty from "lodash/isEmpty";
+import { useFormikContext, getIn } from "formik";
 
 import Overridable from "react-overridable";
 
@@ -22,32 +24,89 @@ function CustomAwardForm({ deserializeFunder, selectedFunding }) {
     if (!funderName && !funderPID) {
       return {};
     }
+    const isVocabFunder = funderPID;
+    const funderText = [funderName, funderCountry, funderPID]
+      .filter(Boolean)
+      .join(", ");
+
+    const dropdownContent = isVocabFunder ? (
+      <div className="ui header">
+        {funderName} (
+        <span>
+          <a
+            href={`https://ror.org/${funderPID}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <img
+              alt={i18next.t("ROR logo")}
+              src="/static/images/ror-icon.svg"
+              className="inline-id-icon mr-5"
+            />
+            {funderPID}
+          </a>
+        </span>
+        ){funderCountry && <div className="sub header">{funderCountry}</div>}
+      </div>
+    ) : null;
 
     return {
-      text: [funderName, funderCountry, funderPID].filter((val) => val).join(", "),
-      value: funderItem.id,
-      key: funderItem.id,
+      id: funderPID,
+      // Used when selected
+      text: funderText,
+      // Used in dropdown list
+      content: dropdownContent || funderText,
+      value: funderPID || funderName,
+      key: funderPID || funderName,
       ...(funderName && { name: funderName }),
       ...(funderPID && { pid: funderPID }),
     };
   }
-
   function serializeFunderFromDropdown(funderDropObject) {
-    return {
-      id: funderDropObject.key,
-      ...(funderDropObject.name && { name: funderDropObject.name }),
-      ...(funderDropObject.pid && { pid: funderDropObject.pid }),
-    };
+    const isVocabFunder = funderDropObject.id;
+
+    let result;
+    if (isVocabFunder) {
+      result = {
+        id: funderDropObject.id,
+        ...(funderDropObject.name && { name: funderDropObject.name }),
+        ...(funderDropObject.pid && { pid: funderDropObject.pid }),
+      };
+    } else {
+      result = {
+        name: funderDropObject.name,
+      };
+    }
+    return result;
   }
+
+  const funderPath = "selectedFunding.funder";
+  const { values } = useFormikContext();
+  const currentFunder = getIn(values, funderPath);
+
+  const initialSuggestions = currentFunder
+    ? [deserializeFunderToDropdown(currentFunder)]
+    : [];
+
+  const handleFunderChange = ({ formikProps }, selectedFundersArray) => {
+    if (!selectedFundersArray || selectedFundersArray.length === 0) {
+      formikProps.form.setFieldValue(funderPath, undefined);
+    } else {
+      const deserializedFunder = serializeFunderFromDropdown(
+        selectedFundersArray.at(-1)
+      );
+      formikProps.form.setFieldValue(funderPath, deserializedFunder);
+    }
+  };
 
   return (
     <Form>
       <Overridable
         id="InvenioVocabularies.CustomAwardForm.RemoteSelectField.Container"
-        fieldPath="selectedFunding.funder.id"
+        fieldPath={funderPath}
       >
         <RemoteSelectField
-          fieldPath="selectedFunding.funder.id"
+          fieldPath={funderPath}
           suggestionAPIUrl="/api/funders"
           suggestionAPIHeaders={{
             Accept: "application/vnd.inveniordm.v1+json",
@@ -58,31 +117,21 @@ function CustomAwardForm({ deserializeFunder, selectedFunding }) {
               deserializeFunderToDropdown(deserializeFunder(funder))
             );
           }}
+          initialSuggestions={initialSuggestions}
           searchInput={{
             autoFocus: _isEmpty(selectedFunding),
           }}
           label={i18next.t("Funder")}
           noQueryMessage={i18next.t("Search for funder...")}
           clearable
-          allowAdditions={false}
+          allowAdditions
           multiple={false}
           selectOnBlur={false}
           selectOnNavigation={false}
           required
-          search={(options) => options}
-          isFocused
-          onValueChange={({ formikProps }, selectedFundersArray) => {
-            if (selectedFundersArray.length === 1) {
-              const selectedFunder = selectedFundersArray[0];
-              if (selectedFunder) {
-                const deserializedFunder = serializeFunderFromDropdown(selectedFunder);
-                formikProps.form.setFieldValue(
-                  "selectedFunding.funder",
-                  deserializedFunder
-                );
-              }
-            }
-          }}
+          value={currentFunder?.id || currentFunder?.name || ""}
+          isFocused={currentFunder ? false : true}
+          onValueChange={handleFunderChange}
         />
       </Overridable>
       <Overridable id="InvenioVocabularies.CustomAwardForm.AwardInformationHeader.Container">

--- a/invenio_vocabularies/assets/semantic-ui/js/invenio_vocabularies/src/contrib/forms/Funding/FundingModal.js
+++ b/invenio_vocabularies/assets/semantic-ui/js/invenio_vocabularies/src/contrib/forms/Funding/FundingModal.js
@@ -1,6 +1,7 @@
 // This file is part of InvenioVocabularies
 // Copyright (C) 2021-2024 CERN.
 // Copyright (C) 2021 Northwestern University.
+// Copyright (C) 2026 ZBW – Leibniz-Informationszentrum Wirtschaft.
 //
 // Invenio is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
@@ -48,9 +49,18 @@ const StandardSchema = Yup.object().shape({
 
 const CustomFundingSchema = Yup.object().shape({
   selectedFunding: Yup.object().shape({
-    funder: Yup.object().shape({
-      id: Yup.string().required(i18next.t("Funder is required.")),
-    }),
+    funder: Yup.object()
+      .shape({
+        id: Yup.string(),
+        name: Yup.string(),
+      })
+      .test({
+        name: "funderRequired",
+        message: i18next.t("Funder is required."),
+        test: function (value) {
+          return value?.id || value?.name;
+        },
+      }),
     award: Yup.object().shape({
       title: Yup.string(),
       number: Yup.string(),

--- a/invenio_vocabularies/assets/semantic-ui/js/invenio_vocabularies/src/contrib/forms/Funding/FundingModal.js
+++ b/invenio_vocabularies/assets/semantic-ui/js/invenio_vocabularies/src/contrib/forms/Funding/FundingModal.js
@@ -1,6 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2021-2024 CERN.
  * SPDX-FileCopyrightText: 2021 Northwestern University.
+ * SPDX-FileCopyrightText: 2026 ZBW – Leibniz-Informationszentrum Wirtschaft.
  * SPDX-License-Identifier: MIT
  */
 
@@ -47,9 +48,18 @@ const StandardSchema = Yup.object().shape({
 
 const CustomFundingSchema = Yup.object().shape({
   selectedFunding: Yup.object().shape({
-    funder: Yup.object().shape({
-      id: Yup.string().required(i18next.t("Funder is required.")),
-    }),
+    funder: Yup.object()
+      .shape({
+        id: Yup.string(),
+        name: Yup.string(),
+      })
+      .test({
+        name: "funderRequired",
+        message: i18next.t("Funder is required."),
+        test: function (value) {
+          return value?.id || value?.name;
+        },
+      }),
     award: Yup.object().shape({
       title: Yup.string(),
       number: Yup.string(),


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Fixes https://github.com/inveniosoftware/invenio-app-rdm/issues/2226 (and adds ROR icon to dropdown entries to align with creatributor styling).

Changes:

- allow yup validation to accept either `id` or `name`
- wrap component in `Field` for formik access
- serialize non-vocab funders with just `name`
- deserialize funders to rich content when used in search results, otherwise use space separated inline text

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [X] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
