### PR TITLE
fix(schema): use SanitizedUnicode for i18n_strings values

### DIFF
--- a/invenio_vocabularies/services/schema.py
+++ b/invenio_vocabularies/services/schema.py
@@ -29,7 +29,7 @@ from marshmallow_utils.fields import SanitizedUnicode
 i18n_strings = fields.Dict(
     allow_none=False,
     keys=fields.Str(validate=validate.Regexp("^[a-z]{2}$")),
-    values=fields.Str(),
+    values=SanitizedUnicode(),
 )
 """Field definition for language aware strings."""
 


### PR DESCRIPTION
This PR fixes problems with control characters making XML export formats fail.
Related PR: inveniosoftware/invenio-rdm-records#2335

1. Create a new record
2. Define a custom award/grant with a title containing Unicode control characters
    1. Generate some text with a control character with the command: `printf 'before stx \002 after stx' > stx_file.txt`
    2. Copy the content of file in the award/grant title field:
    <img width="946" height="360" alt="funding-unicode" src="https://github.com/user-attachments/assets/02218ea5-72f8-49a8-805f-448c46dde848" />
3. Publish the record
4. Go to Export, and choose the DataCite XML format
5. This generates the following stacktrace:
```
Traceback (most recent call last):
  File "src/lxml/builder.py", line 162, in lxml.builder.ElementMaker.__init__.add_text
  File "src/lxml/etree.pyx", line 1186, in lxml.etree._Element.__getitem__
IndexError: list index out of range

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/tmp/.venv/lib/python3.9/site-packages/flask/app.py", line 1536, in __call__
    return self.wsgi_app(environ, start_response)
  File "/tmp/.venv/lib/python3.9/site-packages/werkzeug/middleware/dispatcher.py", line 81, in __call__
    return app(environ, start_response)
  File "/tmp/.venv/lib/python3.9/site-packages/flask/app.py", line 1514, in wsgi_app
    response = self.handle_exception(e)
  File "/tmp/.venv/lib/python3.9/site-packages/flask/app.py", line 1511, in wsgi_app
    response = self.full_dispatch_request()
  File "/tmp/.venv/lib/python3.9/site-packages/flask/app.py", line 919, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/tmp/.venv/lib/python3.9/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
  File "/tmp/.venv/lib/python3.9/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
  File "/tmp/.venv/lib/python3.9/site-packages/invenio_app_rdm/records_ui/views/decorators.py", line 109, in view
    return f(**kwargs)
  File "/tmp/.venv/lib/python3.9/site-packages/invenio_app_rdm/records_ui/views/decorators.py", line 209, in view
    return f(**kwargs)
  File "/tmp/.venv/lib/python3.9/site-packages/invenio_app_rdm/records_ui/views/decorators.py", line 477, in view
    response = make_response(f(*args, **kwargs))
  File "/tmp/.venv/lib/python3.9/site-packages/invenio_app_rdm/records_ui/views/records.py", line 352, in record_export
    exported_record = serializer.serialize_object(record.to_dict())
  File "/tmp/.venv/lib/python3.9/site-packages/flask_resources/serializers/base.py", line 94, in serialize_object
    return self.format_serializer.serialize_object(self.dump_obj(obj))
  File "/tmp/.venv/lib/python3.9/site-packages/flask_resources/serializers/simple.py", line 22, in serialize_object
    return self._encoder(obj)
  File "/tmp/.venv/lib/python3.9/site-packages/datacite/schema43.py", line 53, in tostring
    return etree_to_string(dump_etree(data), **kwargs)
  File "/tmp/.venv/lib/python3.9/site-packages/datacite/schema43.py", line 48, in dump_etree
    return dump_etree_helper(data, rules, ns, root_attribs)
  File "/tmp/.venv/lib/python3.9/site-packages/datacite/xmlutils.py", line 29, in dump_etree_helper
    element = rules[rule](rule, data[rule])
  File "/tmp/.venv/lib/python3.9/site-packages/datacite/schema43.py", line 445, in fundingreferences
    element.append(E.awardTitle(title))
  File "src/lxml/builder.py", line 222, in lxml.builder.ElementMaker.__call__
  File "src/lxml/builder.py", line 164, in lxml.builder.ElementMaker.__init__.add_text
  File "src/lxml/etree.pyx", line 1049, in lxml.etree._Element.text.__set__
  File "src/lxml/apihelpers.pxi", line 748, in lxml.etree._setNodeText
  File "src/lxml/apihelpers.pxi", line 736, in lxml.etree._createTextNode
  File "src/lxml/apihelpers.pxi", line 1541, in lxml.etree._utf8
ValueError: All strings must be XML compatible: Unicode or ASCII, no NULL bytes or control characters
```