### PR TITLE
refactor(schema): Use reusable IdentifierSchema instances instead of partial calls

### DIFF
--- a/invenio_vocabularies/contrib/affiliations/schema.py
+++ b/invenio_vocabularies/contrib/affiliations/schema.py
@@ -4,8 +4,6 @@
 
 """Affiliations schema."""
 
-from functools import partial
-
 from invenio_i18n import lazy_gettext as _
 from marshmallow import fields, validate
 from marshmallow_utils.fields import IdentifierSet, SanitizedUnicode
@@ -25,10 +23,8 @@ class AffiliationSchema(BaseVocabularySchema, ModePIDFieldVocabularyMixin):
     acronym = SanitizedUnicode()
     identifiers = IdentifierSet(
         fields.Nested(
-            partial(
-                IdentifierSchema,
-                allowed_schemes=affiliation_schemes,
-                identifier_required=False,
+            IdentifierSchema(
+                allowed_schemes=affiliation_schemes, identifier_required=False
             )
         )
     )
@@ -56,10 +52,8 @@ class AffiliationRelationSchema(ContribVocabularyRelationSchema):
     name = SanitizedUnicode()
     identifiers = IdentifierSet(
         fields.Nested(
-            partial(
-                IdentifierSchema,
-                allowed_schemes=affiliation_schemes,
-                identifier_required=False,
+            IdentifierSchema(
+                allowed_schemes=affiliation_schemes, identifier_required=False
             )
         ),
         dump_only=True,

--- a/invenio_vocabularies/contrib/awards/schema.py
+++ b/invenio_vocabularies/contrib/awards/schema.py
@@ -3,8 +3,6 @@
 
 """Awards schema."""
 
-from functools import partial
-
 from invenio_i18n import lazy_gettext as _
 from marshmallow import Schema, ValidationError, fields, validate, validates_schema
 from marshmallow_utils.fields import IdentifierSet, ISODateString, SanitizedUnicode
@@ -35,11 +33,7 @@ class AwardSchema(BaseVocabularySchema, ModePIDFieldVocabularyMixin):
 
     identifiers = IdentifierSet(
         fields.Nested(
-            partial(
-                IdentifierSchema,
-                allowed_schemes=award_schemes,
-                identifier_required=False,
-            )
+            IdentifierSchema(allowed_schemes=award_schemes, identifier_required=False)
         )
     )
     number = SanitizedUnicode(
@@ -73,11 +67,7 @@ class AwardRelationSchema(Schema):
     title = i18n_strings
     identifiers = IdentifierSet(
         fields.Nested(
-            partial(
-                IdentifierSchema,
-                allowed_schemes=award_schemes,
-                identifier_required=False,
-            )
+            IdentifierSchema(allowed_schemes=award_schemes, identifier_required=False)
         )
     )
     acronym = SanitizedUnicode()

--- a/invenio_vocabularies/contrib/funders/schema.py
+++ b/invenio_vocabularies/contrib/funders/schema.py
@@ -5,8 +5,6 @@
 
 """Funders schema."""
 
-from functools import partial
-
 from invenio_i18n import lazy_gettext as _
 from marshmallow import (
     fields,
@@ -44,11 +42,7 @@ class FunderSchema(BaseVocabularySchema, ModePIDFieldVocabularyMixin):
     location_name = SanitizedUnicode()
     identifiers = IdentifierSet(
         fields.Nested(
-            partial(
-                IdentifierSchema,
-                allowed_schemes=funder_schemes,
-                identifier_required=False,
-            )
+            IdentifierSchema(allowed_schemes=funder_schemes, identifier_required=False)
         )
     )
 

--- a/invenio_vocabularies/contrib/names/schema.py
+++ b/invenio_vocabularies/contrib/names/schema.py
@@ -3,8 +3,6 @@
 
 """Names schema."""
 
-from functools import partial
-
 from invenio_i18n import lazy_gettext as _
 from marshmallow import (
     EXCLUDE,
@@ -48,13 +46,10 @@ class NameSchema(BaseVocabularySchema, ModePIDFieldVocabularyMixin):
     family_name = SanitizedUnicode()
     identifiers = IdentifierSet(
         fields.Nested(
-            partial(
-                IdentifierSchema,
-                # It is intended to allow org schemes to be sent as personal
-                # and viceversa. This is a trade off learnt from running
-                # Zenodo in production.
-                allowed_schemes=names_schemes,
-            )
+            # It is intended to allow org schemes to be sent as personal
+            # and viceversa. This is a trade off learnt from running
+            # Zenodo in production.
+            IdentifierSchema(allowed_schemes=names_schemes)
         )
     )
     affiliations = fields.List(fields.Nested(AffiliationRelationSchema))

--- a/invenio_vocabularies/contrib/subjects/schema.py
+++ b/invenio_vocabularies/contrib/subjects/schema.py
@@ -6,8 +6,6 @@
 
 """Subjects schema."""
 
-from functools import partial
-
 from invenio_i18n import get_locale
 from marshmallow import EXCLUDE, Schema, ValidationError, fields, pre_load, validate
 from marshmallow_utils.fields import URL, IdentifierSet, SanitizedUnicode
@@ -49,11 +47,7 @@ class SubjectSchema(BaseVocabularySchema):
     props = fields.Dict(keys=SanitizedUnicode(), values=StringOrListOfStrings())
     identifiers = IdentifierSet(
         fields.Nested(
-            partial(
-                IdentifierSchema,
-                allowed_schemes=subject_schemes,
-                identifier_required=False,
-            )
+            IdentifierSchema(allowed_schemes=subject_schemes, identifier_required=False)
         )
     )
     synonyms = fields.List(SanitizedUnicode())
@@ -86,11 +80,7 @@ class SubjectRelationSchema(ContribVocabularyRelationSchema):
     props = fields.Dict(dump_only=True)
     identifiers = IdentifierSet(
         fields.Nested(
-            partial(
-                IdentifierSchema,
-                allowed_schemes=subject_schemes,
-                identifier_required=False,
-            )
+            IdentifierSchema(allowed_schemes=subject_schemes, identifier_required=False)
         )
     )
     synonyms = fields.List(SanitizedUnicode(), dump_only=True)


### PR DESCRIPTION
closes: https://github.com/inveniosoftware/invenio-app-rdm/issues/3480
This PR removes `functools.partial` from vocabulary contrib schemas and uses schema instances instead.