### PR TITLE
fix(datastreams): fix OAIPMHReader default parameters

### DIFF
--- a/invenio_vocabularies/datastreams/readers.py
+++ b/invenio_vocabularies/datastreams/readers.py
@@ -293,11 +293,11 @@ class OAIPMHReader(BaseReader):
     ):
         """Constructor."""
         self._base_url = base_url
-        self._metadata_prefix = metadata_prefix if not None else "oai_dc"
+        self._metadata_prefix = metadata_prefix or "oai_dc"
         self._set = set
         self._until = until_date
         self._from = from_date
-        self._verb = verb if not None else "ListRecords"
+        self._verb = verb or "ListRecords"
         super().__init__(*args, **kwargs)
 
     def _iter(self, scythe, *args, **kwargs):


### PR DESCRIPTION
* `metadata_prefix` and `verb` have a typo in their ternary expressions evaluating to `None` if no value is passed to the constructor, causing the defaults `"oai_dc"` and `"ListRecords"` to never be applied.