### PR TITLE
funding: make funding item button order match

### DIFF
--- a/invenio_vocabularies/assets/semantic-ui/js/invenio_vocabularies/src/contrib/forms/Funding/FundingFieldItem.js
+++ b/invenio_vocabularies/assets/semantic-ui/js/invenio_vocabularies/src/contrib/forms/Funding/FundingFieldItem.js
@@ -68,6 +68,9 @@ export const FundingFieldItem = ({
         className={hidden ? "deposit-drag-listitem hidden" : "deposit-drag-listitem"}
       >
         <List.Content floated="right">
+          <Button size="mini" type="button" onClick={() => removeFunding(index)}>
+            {i18next.t("Remove")}
+          </Button>
           <FundingModal
             searchConfig={searchConfig}
             onAwardChange={(selectedFunding) => {
@@ -85,9 +88,6 @@ export const FundingFieldItem = ({
             computeFundingContents={computeFundingContents}
             initialFunding={fundingItem}
           />
-          <Button size="mini" type="button" onClick={() => removeFunding(index)}>
-            {i18next.t("Remove")}
-          </Button>
         </List.Content>
 
         <Ref innerRef={drag}>


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

We've had a lot of discussion about button order https://github.com/inveniosoftware/invenio-rdm-records/pull/1811 , but somehow missed that the funder button order doesn't match. This swap makes it match the rest of the deposit form

Current: 
<img width="1143" height="93" alt="Screenshot 2026-06-08 at 5 39 08 PM" src="https://github.com/user-attachments/assets/38b44ef1-800c-497c-a1da-d3a0cbfea0bc" />

After PR:

<img width="1143" height="223" alt="Screenshot 2026-06-08 at 5 38 10 PM" src="https://github.com/user-attachments/assets/8be2c066-a620-4526-a259-977761d62dc2" />




### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
