### PR TITLE
datastreams: flag skipped entry logs for sentry filtering

### DIFF
--- a/invenio_vocabularies/services/tasks.py
+++ b/invenio_vocabularies/services/tasks.py
@@ -24,8 +24,11 @@ def process_datastream(config):
     entries_with_errors = 0
     for result in ds.process():
         if result.errors:
-            current_app.logger.warning(
-                "Skipped entry %s with errors: %s", result.entry, result.errors
+            current_app.logger.error(
+                "Skipped entry %s with errors: %s",
+                result.entry,
+                result.errors,
+                extra={"skip_sentry": True},
             )
             entries_with_errors += 1
 


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description
Closes https://github.com/CERNDocumentServer/cds-rdm/issues/813
Related pr: https://github.com/inveniosoftware/invenio-logging/pull/90

This changes skipped datastream entries from warnings to errors so they are easier to spot in job logs, and also stops logging the full raw entry in the message. I’m also tagging these log records with \skip_sentry=True so they can still show up in the logs but be dropped before they are reported to Sentry.


<img width="1350" height="215" alt="image" src="https://github.com/user-attachments/assets/7de1bffd-37cf-41ad-84b0-de0580094162" />






### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
