### PR TITLE
fix(datastreams): OpenAIREHTTPReader allowing to match several tar filenames

### DIFF
--- a/invenio_vocabularies/contrib/affiliations/datastreams.py
+++ b/invenio_vocabularies/contrib/affiliations/datastreams.py
@@ -227,7 +227,7 @@ An origin is required for the reader.
 
 DATASTREAM_CONFIG_OPENAIRE = {
     "readers": [
-        {"type": "openaire-http", "args": {"tar_href": "/organization.tar"}},
+        {"type": "openaire-http", "args": {"tar_hrefs": ["/organization.tar"]}},
         {
             "type": "tar",
             "args": {

--- a/invenio_vocabularies/contrib/common/openaire/datastreams.py
+++ b/invenio_vocabularies/contrib/common/openaire/datastreams.py
@@ -15,9 +15,9 @@ from invenio_vocabularies.datastreams.readers import BaseReader
 class OpenAIREHTTPReader(BaseReader):
     """OpenAIRE HTTP Reader returning an in-memory binary stream of the latest OpenAIRE Graph Dataset tar file of a given type."""
 
-    def __init__(self, origin=None, mode="r", tar_href=None, *args, **kwargs):
+    def __init__(self, origin=None, mode="r", tar_hrefs=None, *args, **kwargs):
         """Constructor."""
-        self.tar_href = tar_href
+        self.tar_hrefs = tar_hrefs
         super().__init__(origin, mode, *args, **kwargs)
 
     def _iter(self, fp, *args, **kwargs):
@@ -53,16 +53,16 @@ class OpenAIREHTTPReader(BaseReader):
         # Extract the Landing page Link Set Object located as the first (index 0) item.
         landing_page_linkset = api_resp.json()["linkset"][0]
 
-        # Extract the URL of the only tar file matching `tar_href` linked to the record.
+        # Extract the URL of the only tar file matching `tar_hrefs` linked to the record.
         landing_page_matching_tar_items = [
             item
             for item in landing_page_linkset["item"]
             if item["type"] == "application/x-tar"
-            and item["href"].endswith(self.tar_href)
+            and item["href"].endswith(tuple(self.tar_hrefs))
         ]
         if len(landing_page_matching_tar_items) != 1:
             raise ReaderError(
-                f"Expected 1 tar item matching {self.tar_href} but got {len(landing_page_matching_tar_items)}"
+                f"Expected 1 tar item matching {self.tar_hrefs} but got {len(landing_page_matching_tar_items)}"
             )
         file_url = landing_page_matching_tar_items[0]["href"]
 

--- a/invenio_vocabularies/jobs.py
+++ b/invenio_vocabularies/jobs.py
@@ -118,7 +118,10 @@ class ImportAwardsOpenAIREJob(ProcessDataStreamJob):
                 "readers": [
                     {
                         "type": "openaire-http",
-                        "args": {"origin": "diff", "tar_href": "/project.tar"},
+                        "args": {
+                            "origin": "diff",
+                            "tar_hrefs": ["/project.tar", "/projects.tar"],
+                        },
                     },
                     {
                         "type": "tar",

--- a/tests/contrib/common/openaire/test_openaire_datastreams.py
+++ b/tests/contrib/common/openaire/test_openaire_datastreams.py
@@ -50,7 +50,7 @@ API_JSON_RESPONSE_CONTENT_WRONG_NUMBER_PROJECT_TAR_ITEMS_ERROR = {
                     "type": "application/x-tar",
                 },
                 {
-                    "href": "https://example.com/another/project.tar",
+                    "href": "https://example.com/another/projects.tar",
                     "type": "application/x-tar",
                 },
             ],
@@ -91,7 +91,9 @@ def download_file_bytes_content():
     side_effect=lambda url, headers=None: MockResponse(API_JSON_RESPONSE_CONTENT),
 )
 def test_openaire_http_reader(_, download_file_bytes_content):
-    reader = OpenAIREHTTPReader(origin="full", tar_href="/project.tar")
+    reader = OpenAIREHTTPReader(
+        origin="full", tar_hrefs=["/project.tar", "/projects.tar"]
+    )
     results = []
     for entry in reader.read():
         results.append(entry)
@@ -108,7 +110,9 @@ def test_openaire_http_reader(_, download_file_bytes_content):
     ),
 )
 def test_openaire_http_reader_wrong_number_tar_items_error(_):
-    reader = OpenAIREHTTPReader(origin="full", tar_href="/project.tar")
+    reader = OpenAIREHTTPReader(
+        origin="full", tar_hrefs=["/project.tar", "/projects.tar"]
+    )
     with pytest.raises(ReaderError):
         next(reader.read())
 


### PR DESCRIPTION
The version v27 of the record "OpenAIRE Graph dataset: new collected projects" (https://doi.org/10.5281/zenodo.20407508) has a file named "projects.tar" (plural), while in previous versions it was called "project.tar" (singular).

The code also needs to work with the full dump "OpenAIRE Graph Dataset", which at least in version 11.1.1 (https://doi.org/10.5281/zenodo.20428976) is still named "project.tar" (singular).

This pull request proposes to check for both variants.