### PR TITLE
fix default writer values

### DIFF
--- a/invenio_vocabularies/contrib/affiliations/datastreams.py
+++ b/invenio_vocabularies/contrib/affiliations/datastreams.py
@@ -22,8 +22,8 @@ class AffiliationsServiceWriter(ServiceWriter):
 
     def __init__(self, *args, **kwargs):
         """Constructor."""
-        service_or_name = kwargs.pop("service_or_name", "affiliations")
-        super().__init__(service_or_name=service_or_name, *args, **kwargs)
+        kwargs.setdefault("service_or_name", "affiliations")
+        super().__init__(*args, **kwargs)
 
     def _entry_id(self, entry):
         """Get the id from an entry."""
@@ -85,12 +85,12 @@ class OpenAIREAffiliationsServiceWriter(ServiceWriter):
 
     def __init__(self, *args, **kwargs):
         """Constructor."""
-        service_or_name = kwargs.pop("service_or_name", "affiliations")
-        # Here we only update and we do not insert, since OpenAIRE data is used to augment existing affiliations
-        # (with PIC identifiers) and is not used to create new affiliations.
-        super().__init__(
-            service_or_name=service_or_name, insert=False, update=True, *args, **kwargs
-        )
+        kwargs.setdefault("service_or_name", "affiliations")
+        # By default we only update and we do not insert, since OpenAIRE data is used to augment
+        # existing affiliations (with PIC identifiers) and is not used to create new affiliations.
+        kwargs.setdefault("insert", False)
+        kwargs.setdefault("update", True)
+        super().__init__(*args, **kwargs)
 
     def _entry_id(self, entry):
         """Get the id from an entry."""

--- a/invenio_vocabularies/contrib/awards/datastreams.py
+++ b/invenio_vocabularies/contrib/awards/datastreams.py
@@ -30,8 +30,8 @@ class AwardsServiceWriter(ServiceWriter):
 
     def __init__(self, *args, **kwargs):
         """Constructor."""
-        service_or_name = kwargs.pop("service_or_name", "awards")
-        super().__init__(service_or_name=service_or_name, *args, **kwargs)
+        kwargs.setdefault("service_or_name", "awards")
+        super().__init__(*args, **kwargs)
 
     def _entry_id(self, entry):
         """Get the id from an entry."""
@@ -414,12 +414,13 @@ class CORDISAwardsServiceWriter(ServiceWriter):
 
     def __init__(self, *args, **kwargs):
         """Constructor."""
-        service_or_name = kwargs.pop("service_or_name", "awards")
-        # Here we only update and we do not insert, since CORDIS data is used to augment existing awards
-        # (with subjects, organizations, and program information) and is not used to create new awards.
-        super().__init__(
-            service_or_name=service_or_name, insert=False, update=True, *args, **kwargs
-        )
+        kwargs.setdefault("service_or_name", "awards")
+        # By default we only update and we do not insert, since CORDIS data is used to augment
+        # existing awards (with subjects, organizations, and program information) and is not
+        # used to create new awards.
+        kwargs.setdefault("insert", False)
+        kwargs.setdefault("update", True)
+        super().__init__(*args, **kwargs)
 
     def _entry_id(self, entry):
         """Get the id from an entry."""

--- a/invenio_vocabularies/contrib/common/ror/datastreams.py
+++ b/invenio_vocabularies/contrib/common/ror/datastreams.py
@@ -91,7 +91,7 @@ class RORTransformer(BaseTransformer):
         ror = {}
         ror["title"] = {}
 
-        domains = record.get("domains", "")
+        domains = record.get("domains")
         if domains:
             ror["domains"] = domains
 

--- a/invenio_vocabularies/contrib/funders/datastreams.py
+++ b/invenio_vocabularies/contrib/funders/datastreams.py
@@ -15,8 +15,8 @@ class FundersServiceWriter(ServiceWriter):
 
     def __init__(self, *args, **kwargs):
         """Constructor."""
-        service_or_name = kwargs.pop("service_or_name", "funders")
-        super().__init__(service_or_name=service_or_name, *args, **kwargs)
+        kwargs.setdefault("service_or_name", "funders")
+        super().__init__(*args, **kwargs)
 
     def _entry_id(self, entry):
         """Get the id from an entry."""

--- a/invenio_vocabularies/contrib/names/datastreams.py
+++ b/invenio_vocabularies/contrib/names/datastreams.py
@@ -385,8 +385,8 @@ class NamesServiceWriter(ServiceWriter):
 
     def __init__(self, *args, **kwargs):
         """Constructor."""
-        service_or_name = kwargs.pop("service_or_name", "names")
-        super().__init__(service_or_name=service_or_name, *args, **kwargs)
+        kwargs.setdefault("service_or_name", "names")
+        super().__init__(*args, **kwargs)
 
     def _entry_id(self, entry):
         """Get the id from an entry."""

--- a/invenio_vocabularies/contrib/subjects/datastreams.py
+++ b/invenio_vocabularies/contrib/subjects/datastreams.py
@@ -18,8 +18,8 @@ class SubjectsServiceWriter(ServiceWriter):
 
     def __init__(self, *args, **kwargs):
         """Constructor."""
-        service_or_name = kwargs.pop("service_or_name", "subjects")
-        super().__init__(service_or_name=service_or_name, *args, **kwargs)
+        kwargs.setdefault("service_or_name", "subjects")
+        super().__init__(*args, **kwargs)
 
     def _entry_id(self, entry):
         """Get the id from an entry."""

--- a/invenio_vocabularies/datastreams/tasks.py
+++ b/invenio_vocabularies/datastreams/tasks.py
@@ -48,7 +48,9 @@ def write_entry(writer_config, entry, subtask_run_id=None):
             )
     except Exception as exc:
         # The actionable bugs are logged as errors to send to Sentry
-        current_app.logger.error("Error writing entry: %s", exc, extra={"entry": entry})
+        current_app.logger.error(
+            "Error writing entry: %s", exc, exc_info=True, extra={"entry": entry}
+        )
         if subtask_run_id and job_id:
             current_runs_service.finalize_subtask(
                 system_identity,


### PR DESCRIPTION
- **fix(datastreams): allow overriding writer defaults**
  * Writer subclasses passed their defaults directly in the `super().__init__()`
    call, so configuring `insert`/`update`/`service_or_name` from a datastream
    config raised `TypeError: got multiple values for keyword argument`. The
    CORDIS awards and OpenAIRE affiliations writers were unconfigurable as a
    result, since both pinned `insert=False, update=True`.
  * Defaults are now applied with `kwargs.setdefault()` before delegating, which
    keeps the same behaviour when nothing is passed and lets callers override any
    of them.
  

- **fix(ror): drop invalid string default for domains**
  

- **fix(datastreams): log write_entry failures with a stack trace**
  * Without `exc_info`, Sentry groups on the message template alone, so every
    failure in this task gets groupped into one issue.
  