### PR TITLE
fix(contrib): display all funders api search results

### DIFF
--- a/invenio_vocabularies/assets/semantic-ui/js/invenio_vocabularies/src/contrib/forms/Funding/CustomAwardForm.js
+++ b/invenio_vocabularies/assets/semantic-ui/js/invenio_vocabularies/src/contrib/forms/Funding/CustomAwardForm.js
@@ -118,6 +118,7 @@ function CustomAwardForm({ deserializeFunder, selectedFunding }) {
             );
           }}
           initialSuggestions={initialSuggestions}
+          search={(options) => [...options]}
           searchInput={{
             autoFocus: _isEmpty(selectedFunding),
           }}


### PR DESCRIPTION
  * without the search prop, semantic-ui does extra filtering on the API hits, thus neglecting the already in place backend search filters
  * re-add the search prop with a twist - force recomputation of the options array because otherwise the options list will be polluted with "Add " options (again added by the semantic-ui component from allowAdditions)
  * the end result is displaying only one Add option + all the API search hits

Before:

https://github.com/user-attachments/assets/88d3413f-8a83-4c99-8a8a-4dc685c51323

After:

https://github.com/user-attachments/assets/c5bfc0c4-632f-4de5-8d93-acb81f431e8b


