### PR TITLE
feat(awards): add website field populated from CORDIS

### DIFF
--- a/invenio_vocabularies/contrib/awards/datastreams.py
+++ b/invenio_vocabularies/contrib/awards/datastreams.py
@@ -314,6 +314,27 @@ class CORDISProjectTransformer(BaseTransformer):
         if short_description:
             award["short_description"] = {"en": short_description}
 
+        # The `website` field, i.e. the project's own website. CORDIS lists it
+        # among the web links, alongside deliverables and social media accounts.
+        web_links = (
+            record.get("relations", {}).get("associations", {}).get("weblink") or []
+        )
+        # Projects with a single web link are not wrapped in a list.
+        if isinstance(web_links, dict):
+            web_links = [web_links]
+        website = next(
+            (
+                link["physurl"]
+                for link in web_links
+                if link.get("@type") == "relatedWebsite"
+                and link.get("@represents") == "project"
+                and link.get("physurl")
+            ),
+            None,
+        )
+        if website:
+            award["website"] = website
+
         # The `subjects` field.
         categories = record.get("relations", {}).get("categories", {}).get("category")
         if categories:

--- a/invenio_vocabularies/contrib/awards/jsonschemas/awards/award-v1.0.0.json
+++ b/invenio_vocabularies/contrib/awards/jsonschemas/awards/award-v1.0.0.json
@@ -43,6 +43,10 @@
     "program": {
       "type": "string"
     },
+    "website": {
+      "description": "Award's website.",
+      "type": "string"
+    },
     "short_description": {
       "$ref": "local://vocabularies/definitions-v1.0.0.json#/description"
     },

--- a/invenio_vocabularies/contrib/awards/mappings/os-v1/awards/award-v1.0.0.json
+++ b/invenio_vocabularies/contrib/awards/mappings/os-v1/awards/award-v1.0.0.json
@@ -85,6 +85,9 @@
       "program": {
         "type": "keyword"
       },
+      "website": {
+        "type": "keyword"
+      },
       "short_description": {
         "type": "object",
         "dynamic": "true"

--- a/invenio_vocabularies/contrib/awards/mappings/os-v2/awards/award-v1.0.0.json
+++ b/invenio_vocabularies/contrib/awards/mappings/os-v2/awards/award-v1.0.0.json
@@ -85,6 +85,9 @@
       "program": {
         "type": "keyword"
       },
+      "website": {
+        "type": "keyword"
+      },
       "short_description": {
         "type": "object",
         "dynamic": "true"

--- a/invenio_vocabularies/contrib/awards/mappings/v7/awards/award-v1.0.0.json
+++ b/invenio_vocabularies/contrib/awards/mappings/v7/awards/award-v1.0.0.json
@@ -85,6 +85,9 @@
       "program": {
         "type": "keyword"
       },
+      "website": {
+        "type": "keyword"
+      },
       "short_description": {
         "type": "object",
         "dynamic": "true"

--- a/invenio_vocabularies/contrib/awards/schema.py
+++ b/invenio_vocabularies/contrib/awards/schema.py
@@ -14,7 +14,7 @@ from marshmallow import (
     validate,
     validates_schema,
 )
-from marshmallow_utils.fields import IdentifierSet, ISODateString, SanitizedUnicode
+from marshmallow_utils.fields import URL, IdentifierSet, ISODateString, SanitizedUnicode
 from marshmallow_utils.schemas import IdentifierSchema
 
 from ...services.schema import (
@@ -90,6 +90,8 @@ class AwardSchema(BaseVocabularySchema, ModePIDFieldVocabularyMixin):
     acronym = SanitizedUnicode()
 
     program = SanitizedUnicode()
+
+    website = URL()
 
     short_description = i18n_strings
 

--- a/invenio_vocabularies/contrib/awards/serializer.py
+++ b/invenio_vocabularies/contrib/awards/serializer.py
@@ -35,6 +35,7 @@ class AwardL10NItemSchema(Schema):
     acronym = fields.String(dump_only=True)
     program = fields.String(dump_only=True)
     short_description = L10NString(data_key="short_description_l10n")
+    website = fields.String(dump_only=True)
     funder = fields.Nested(FunderRelationSchema, dump_only=True)
     subjects = fields.List(fields.Nested(SubjectRelationSchema), dump_only=True)
     identifiers = fields.List(fields.Nested(IdentifierSchema), dump_only=True)

--- a/tests/contrib/awards/test_awards_datastreams.py
+++ b/tests/contrib/awards/test_awards_datastreams.py
@@ -160,6 +160,14 @@ This technology is based on; Biontronic Chemistry (BC) which combines Bioorthogo
 				<code>ERC-2023-STG</code>
 				<frameworkProgramme>HORIZON</frameworkProgramme>
 			</programme>
+			<webLink type="projectDeliverable" source="corda">
+				<title>Data management plan</title>
+				<physUrl>https://ec.europa.eu/research/participants/documents/downloadPublic?documentIds=080166e5&amp;appId=PPGMS</physUrl>
+			</webLink>
+			<webLink type="relatedWebsite" source="editorial" represents="project">
+				<title>project website</title>
+				<physUrl>https://time2switch.eu/</physUrl>
+			</webLink>
 		</associations>
 		<categories>
 			<category classification="euroSciVoc" type="isInFieldOfScience">
@@ -207,6 +215,7 @@ This technology is based on; Biontronic Chemistry (BC) which combines Bioorthogo
             "en": "I envision a new drug delivery system capable spatiotemporal release with electronic precision.This technology is based on; Biontronic Chemistry (BC) which combines Bioorthogonal Release (BR) and Iontronic transport to overcome the drawbacks of each "
         },
         "program": "HORIZON.1.1",
+        "website": "https://time2switch.eu/",
         "subjects": [{"id": "euroscivoc:225"}],
         "organizations": [{"name": "TECHNISCHE UNIVERSITAET WIEN"}],
     }


### PR DESCRIPTION
* Awards had nowhere to record a project's own website. The
  `identifiers` list cannot hold one, since only a single identifier per
  scheme is allowed and `url` should be used for the CORDIS project link.
